### PR TITLE
Change from +nodes to +walltime

### DIFF
--- a/vasp_manager/calculation_manager/bulkmod.py
+++ b/vasp_manager/calculation_manager/bulkmod.py
@@ -111,7 +111,11 @@ class BulkmodCalculationManager(BaseCalculationManager):
         use_spin = len(rlx_mags) != 0
         return use_spin
 
-    def setup_calc(self, increase_nodes_by_factor=1):
+    def setup_calc(
+        self,
+        increase_nodes_by_factor=1,
+        increase_walltime_by_factor=1,
+    ):
         """
         Sets up an EOS bulkmod calculation
         """
@@ -182,7 +186,7 @@ class BulkmodCalculationManager(BaseCalculationManager):
                     logger.info(f"Rerunning {self.calc_path}")
                     # increase nodes as its likely the calculation failed
                     self._from_scratch()
-                    self.setup_calc(increase_nodes_by_factor=2)
+                    self.setup_calc(increase_walltime_by_factor=2)
                 return False
         return True
 

--- a/vasp_manager/calculation_manager/elastic.py
+++ b/vasp_manager/calculation_manager/elastic.py
@@ -73,7 +73,11 @@ class ElasticCalculationManager(BaseCalculationManager):
         use_spin = len(rlx_mags) != 0
         return use_spin
 
-    def setup_calc(self, increase_nodes_by_factor=2, increase_walltime_by_factor=1):
+    def setup_calc(
+        self,
+        increase_nodes_by_factor=2,
+        increase_walltime_by_factor=1,
+    ):
         """
         Runs elastic constants routine through VASP
 

--- a/vasp_manager/calculation_manager/rlx.py
+++ b/vasp_manager/calculation_manager/rlx.py
@@ -76,7 +76,13 @@ class RlxCalculationManager(BaseCalculationManager):
             name=self.material_name,
         )
 
-    def setup_calc(self, increase_nodes_by_factor=1, make_archive=False, use_spin=True):
+    def setup_calc(
+        self,
+        increase_nodes_by_factor=1,
+        increase_walltime_by_factor=1,
+        make_archive=False,
+        use_spin=True,
+    ):
         """
         Sets up a fine relaxation
         """
@@ -157,7 +163,7 @@ class RlxCalculationManager(BaseCalculationManager):
                 logger.info(f"Rerunning {self.calc_path}")
                 # increase nodes as its likely the calculation failed
                 self.setup_calc(
-                    increase_nodes_by_factor=2, make_archive=True, use_spin=use_spin
+                    increase_walltime_by_factor=2, make_archive=True, use_spin=use_spin
                 )
             return False
 

--- a/vasp_manager/calculation_manager/rlx_coarse.py
+++ b/vasp_manager/calculation_manager/rlx_coarse.py
@@ -65,7 +65,12 @@ class RlxCoarseCalculationManager(BaseCalculationManager):
             name=self.material_name,
         )
 
-    def setup_calc(self, increase_nodes_by_factor=1, make_archive=False):
+    def setup_calc(
+        self,
+        increase_nodes_by_factor=1,
+        increase_walltime_by_factor=1,
+        make_archive=False,
+    ):
         """
         Sets up a coarse relaxation
         """
@@ -138,7 +143,7 @@ class RlxCoarseCalculationManager(BaseCalculationManager):
             if self.to_rerun:
                 logger.info(f"Rerunning {self.calc_path}")
                 # increase nodes as its likely the calculation failed
-                self.setup_calc(increase_nodes_by_factor=2, make_archive=True)
+                self.setup_calc(increase_walltime_by_factor=2, make_archive=True)
             return False
 
         logger.info(f"{self.mode.upper()} Calculation: reached required accuracy")


### PR DESCRIPTION
Calculations are typically more efficient on less nodes, and I'd usually rather bump the walltime than the number of nodes to conserve cost