### PR TITLE
Update Quest config after quest8 nodes retired

### DIFF
--- a/calculations/computing_config.json
+++ b/calculations/computing_config.json
@@ -17,7 +17,7 @@
     "allocation": "p31151",
     "vasp_module": "vasp/5.4.4-openmpi-4.0.5-intel-19.0.5.281",
     "ncore": 12,
-    "ncore_per_node": 28
+    "ncore_per_node": 40
   },
   "perlmutter": {
     "user_id": "dwg4898",

--- a/vasp_manager/vasp_input_creator.py
+++ b/vasp_manager/vasp_input_creator.py
@@ -188,24 +188,23 @@ class VaspInputCreator:
         # start with 1 node per 32 atoms
         num_nodes = (len(self.source_structure) // 32) + 1
         if self.computer == "quest":
-            # quest has 4x smaller nodes than perlmutter
+            # quest has ~4x smaller nodes than perlmutter
             num_nodes *= 4
         num_nodes *= self.increase_nodes_by_factor
         return num_nodes
 
     @property
     def n_procs(self):
-        # typically request all processors on each node, and then
-        # leave some ~4/node empty for memory
         n_procs = self.n_nodes * self.computing_config["ncore_per_node"]
         return n_procs
 
     @property
     def n_procs_used(self):
+        # typically request all processors on each node, and then
+        # leave some ~4/node empty for memory
         ncore_per_node = self.computing_config["ncore_per_node"]
-        if self.mode == "elastic":
-            if self.computer == "quest":
-                self.ncore_per_node_for_memory += 8
+        if self.computer == "quest":
+            self.ncore_per_node_for_memory += 4
         return self.n_nodes * (ncore_per_node - self.ncore_per_node_for_memory)
 
     @cached_property


### PR DESCRIPTION
Quest retired the Quest 8 nodes (28 cores per node) in September of 2023. Update quest configuration handling for the new smallest nodes, which are Quest 9 nodes with 40 cores per node.