### PR TITLE
Revert quest job files to include num nodes

### DIFF
--- a/vasp_manager/static_files/vasp-bulkmod-quest.yml
+++ b/vasp_manager/static_files/vasp-bulkmod-quest.yml
@@ -1,4 +1,5 @@
 sbatch_params: |-
+  #SBATCH -N {n_nodes}
   #SBATCH -n {n_procs}
   #SBATCH -p {queuetype}
   #SBATCH -J {jobname}

--- a/vasp_manager/static_files/vasp-quest.yml
+++ b/vasp_manager/static_files/vasp-quest.yml
@@ -1,4 +1,5 @@
 sbatch_params: |-
+  #SBATCH -N {n_nodes}
   #SBATCH -n {n_procs}
   #SBATCH -p {queuetype}
   #SBATCH -J {jobname}


### PR DESCRIPTION
Although the jobs move through the queue faster, the calculations are much slower due to more internode communication