### PR TITLE
Fix bulkmod strain symlinks

### DIFF
--- a/vasp_manager/calculation_manager/bulkmod.py
+++ b/vasp_manager/calculation_manager/bulkmod.py
@@ -241,5 +241,7 @@ class BulkmodCalculationManager(BaseCalculationManager):
 
             with change_directory(strain_path):
                 for f in ["POTCAR", "INCAR"]:
+                    if Path(f).exists():
+                        os.remove(f)
                     orig_path = Path("..") / f
                     os.symlink(orig_path, f, target_is_directory=False)


### PR DESCRIPTION
In the case where the bulkmod strain directories had been created but not submitted, there would be an error when trying to create the symlinks in the strain directories as the file already existed