### PR TITLE
Fix logic of core_per_node_for_memory for quest

### DIFF
--- a/vasp_manager/calculation_manager/base.py
+++ b/vasp_manager/calculation_manager/base.py
@@ -213,7 +213,8 @@ class BaseCalculationManager(ABC):
                         errors_addressed[error] = True
                 case "oom-kill":
                     if vic.computer == "quest":
-                        ncore_per_node_for_memory = 8
+                        # total of 16 (as vic adds 4 if on quest)
+                        ncore_per_node_for_memory = 12
                     else:
                         ncore_per_node_for_memory = 32
                     vic.ncore_per_node_for_memory = ncore_per_node_for_memory

--- a/vasp_manager/vasp_input_creator.py
+++ b/vasp_manager/vasp_input_creator.py
@@ -183,7 +183,7 @@ class VaspInputCreator:
         with open(potcar_path, "w+") as fw:
             fw.write(potcar)
 
-    @property
+    @cached_property
     def n_nodes(self):
         # start with 1 node per 32 atoms
         num_nodes = (len(self.source_structure) // 32) + 1
@@ -193,12 +193,12 @@ class VaspInputCreator:
         num_nodes *= self.increase_nodes_by_factor
         return num_nodes
 
-    @property
+    @cached_property
     def n_procs(self):
         n_procs = self.n_nodes * self.computing_config["ncore_per_node"]
         return n_procs
 
-    @property
+    @cached_property
     def n_procs_used(self):
         # typically request all processors on each node, and then
         # leave some ~4/node empty for memory


### PR DESCRIPTION
Because ncore_per_node_for_memory was a property and was called twice, an incorrect number of cores was set, but only for quest.