### PR TITLE
Update standalone calculation management

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,17 +55,17 @@ scripts.
 ### Calculation Modes
 
 We include calculation modes `"rlx-coarse"`, `"rlx"`, `"static"`, `"bulkmod"`,
-`"bulkmod_standalone"`, and `"elastic"`.  The desired modes to calculate are
-specified when initializing a `VaspManager` object.
+and `"elastic"`.  The desired modes to calculate are specified when
+initializing a `VaspManager` object.
 
 * `rlx-coarse`: lower precision energy-based relaxation
 * `rlx`: tighter force-based relaxation
 * `static`: high accuracy static SCF calculation
 * `bulkmod`: bulk modulus calculation using an Equation of State (EOS) fit to an
 energy-volume curve
-  * `bulkmod_standalone`: standalone (no relaxation required) bulk modulus
-    calculation using an EOS (although this is not recommended unless you are
-    sure the cell volume is very close to the equilibrium value)
+  * Can be run as a standalone (no relaxation required) calculation of bulk
+    modulus using an EOS (although this is not recommended unless you are sure
+    the cell volume is very close to the equilibrium value)
 * `elastic`: Determination of elastic constants using the strain/deformation
 method built into `VASP`
 
@@ -73,10 +73,11 @@ I generally recommend starting from `rlx-coarse`, although the functionality is
 there to start a `rlx` calculation from the initially provided POSCAR.
 
 Most users' workflows follow `rlx-coarse` &#8594; `rlx` &#8594; `static`. The
-modes `static`, `bulkmod`, and `elastic` require at least `rlx` preceding it,
-but can all be run independently of each other.  For example, workflows might
-look like `rlx-coarse` &#8594; `rlx` &#8594; `static` &#8594; `bulkmod`, or
-`rlx` &#8594; `elastic`, or simply `bulkmod_standalone`.
+modes `static`, `bulkmod`, and `elastic` can all be run independently of each
+other. For example, workflows might look like `rlx-coarse` &#8594; `rlx` &#8594;
+`static` &#8594; `bulkmod`, or `rlx` &#8594; `elastic`, or simply `bulkmod`.
+The `elastic` mode requires at least `rlx` preceding it in order to guarantee
+converged lattice parameters and atomic positions.
 
 ## Usage Guide
 

--- a/vasp_manager/vasp_input_creator.py
+++ b/vasp_manager/vasp_input_creator.py
@@ -57,18 +57,10 @@ class VaspInputCreator:
         self.increase_nodes_by_factor = int(increase_nodes_by_factor)
         self.increase_walltime_by_factor = int(increase_walltime_by_factor)
         self.name = name
-        self.mode = self._get_mode(mode)
+        self.mode = mode
         self.poscar_significant_figures = poscar_significant_figures
         self.ncore_per_node_for_memory = ncore_per_node_for_memory
         self.use_spin = use_spin
-
-    def _get_mode(self, mode):
-        # rlx-coarse, rlx, bulkmod, stc, or elastic
-        # needed to add this to ensure bulkmod or bulkmod_standalone
-        # share same config
-        if "bulkmod" in mode:
-            mode = "bulkmod"
-        return mode
 
     @cached_property
     def calc_config_dict(self):

--- a/vasp_manager/vasp_manager.py
+++ b/vasp_manager/vasp_manager.py
@@ -233,10 +233,7 @@ class VaspManager:
                         **self.calculation_manager_kwargs[calc_type],
                     )
                 case "rlx":
-                    if "rlx-coarse" in self.calculation_types:
-                        from_coarse_relax = True
-                    else:
-                        from_coarse_relax = False
+                    from_coarse_relax = "rlx-coarse" in self.calculation_types
                     manager = RlxCalculationManager(
                         material_path=material_path,
                         to_rerun=self.to_rerun,
@@ -249,28 +246,18 @@ class VaspManager:
                         **self.calculation_manager_kwargs[calc_type],
                     )
                 case "static":
-                    if "rlx" not in self.calculation_types:
-                        msg = "Cannot perform static calculation without mode='rlx' first"
-                        raise Exception(msg)
+                    from_relax = "rlx" in self.calculation_types
                     manager = StaticCalculationManager(
                         material_path=material_path,
                         to_rerun=self.to_rerun,
                         to_submit=self.to_submit,
                         ignore_personal_errors=self.ignore_personal_errors,
+                        from_relax=from_relax,
                         tail=self.tail,
                         **self.calculation_manager_kwargs[calc_type],
                     )
-                case "bulkmod" | "bulkmod_standalone":
-                    if calc_type == "bulkmod" and "rlx" in self.calculation_types:
-                        from_relax = True
-                    else:
-                        from_relax = False
-                        if len(self.calculation_types) > 1:
-                            msg = (
-                                "bulkmod_standalone must be run alone -- remove other"
-                                " calculation types to fix"
-                            )
-                            raise Exception(msg)
+                case "bulkmod":
+                    from_relax = "rlx" in self.calculation_types
                     manager = BulkmodCalculationManager(
                         material_path=material_path,
                         to_rerun=self.to_rerun,


### PR DESCRIPTION
Allow static calculations without a previous relaxation. 
Remove bulkmod_standalone mode and incorporate the expected behavior into the standard bulkmod mode