### PR TITLE
Change core management for elastic calculations

### DIFF
--- a/vasp_manager/calculation_manager/base.py
+++ b/vasp_manager/calculation_manager/base.py
@@ -224,7 +224,7 @@ class BaseCalculationManager(ABC):
                         # total of 16 (as vic adds 4 if on quest)
                         ncore_per_node_for_memory = 12
                     else:
-                        ncore_per_node_for_memory = 32
+                        ncore_per_node_for_memory = 64
                     vic.ncore_per_node_for_memory = ncore_per_node_for_memory
                     errors_addressed[error] = True
                 case _:

--- a/vasp_manager/calculation_manager/elastic.py
+++ b/vasp_manager/calculation_manager/elastic.py
@@ -75,7 +75,7 @@ class ElasticCalculationManager(BaseCalculationManager):
 
     def setup_calc(
         self,
-        increase_nodes_by_factor=2,
+        increase_nodes_by_factor=1,
         increase_walltime_by_factor=1,
     ):
         """

--- a/vasp_manager/tests/test_calculation_managers.py
+++ b/vasp_manager/tests/test_calculation_managers.py
@@ -197,7 +197,7 @@ def test_hit_errors_and_restart(calc_dir):
     assert not rlx_coarse_manager.stopped
     assert rlx_coarse_manager.vasp_input_creator.calc_config["algo"] == "Fast"
     assert rlx_coarse_manager.vasp_input_creator.calc_config["symprec"] == "1e-08"
-    assert rlx_coarse_manager.vasp_input_creator.ncore_per_node_for_memory == 32
+    assert rlx_coarse_manager.vasp_input_creator.ncore_per_node_for_memory == 64
     assert rlx_coarse_manager.results == "not finished"
 
 


### PR DESCRIPTION
Previously, elastic calculations used 2 nodes by default. With fairly low KPAR settings (4 or 8) and large nodes, NCORE would often be >16, leading to high inter-core communication overhead. In my experience, it's often just as fast to use less cores in these cases, leading to this commit. In addition, upon out of memory errors, just use half of the perlmutter nodes for better compatibility with KPAR multiples of 4.