### PR TITLE
Update managers with named loggers

### DIFF
--- a/vasp_manager/analyzer/bulkmod_analyzer.py
+++ b/vasp_manager/analyzer/bulkmod_analyzer.py
@@ -29,7 +29,6 @@ class BulkmodAnalyzer:
 
     @calc_path.setter
     def calc_path(self, value):
-        # make sure cij wasn't already defined
         if not value.exists():
             raise ValueError(f"Could not set calc_path to {value} as it does not exist")
         self._calc_path = value
@@ -73,14 +72,12 @@ class BulkmodAnalyzer:
             final_energy = vasprun.final_energy
             volumes.append(volume)
             final_energies.append(final_energy)
-        logger.debug("Volumes")
-        logger.debug(f"{volumes}")
-        logger.debug("Final Energies")
-        logger.debug(f"{final_energies}")
+        logger.debug(f"Volumes:\n\t{volumes}")
+        logger.debug(f"Final Energies:\n\t{final_energies}")
         eos_analyzer = BirchMurnaghan(volumes, final_energies)
         eos_analyzer.fit()
         bulk_modulus = np.round(eos_analyzer.b0_GPa, rounding_precision)
-        logger.info(f"BULK MODULUS: {bulk_modulus}")
+        logger.debug(f"BULK MODULUS: {bulk_modulus}")
         b_dict = {"B": bulk_modulus}
         return b_dict
 

--- a/vasp_manager/analyzer/elastic_analyzer.py
+++ b/vasp_manager/analyzer/elastic_analyzer.py
@@ -1,17 +1,13 @@
 # Copyright (c) Dale Gaines II
 # Distributed under the terms of the MIT LICENSE
 
-import json
-import logging
 from functools import cached_property
 from pathlib import Path
 
 import numpy as np
 from pymatgen.core import Structure
 
-from vasp_manager.utils import NumpyEncoder, pgrep
-
-logger = logging.getLogger(__name__)
+from vasp_manager.utils import pgrep
 
 
 class ElasticAnalyzer:
@@ -216,12 +212,8 @@ class ElasticAnalyzer:
         "returns True if compound is elastically unstable"
         eigenvalues, eigenvectors = np.linalg.eig(cij)
         born_critera_satisfied = np.all(eigenvalues > 0)
-
-        if not born_critera_satisfied:
-            logger.warning("-" * 10 + " WARNING: Elastically Unstable " + "-" * 10)
-            return True
-
-        return False
+        elastically_unstable = not born_critera_satisfied
+        return elastically_unstable
 
     @cached_property
     def sij(self):
@@ -305,8 +297,6 @@ class ElasticAnalyzer:
         elastic_dict = {}
         for property in properties:
             elastic_dict[property] = getattr(self, properties_map[property])
-        logger.debug(json.dumps(elastic_dict, cls=NumpyEncoder, indent=2))
-
         return elastic_dict
 
     @property

--- a/vasp_manager/calculation_manager/base.py
+++ b/vasp_manager/calculation_manager/base.py
@@ -45,7 +45,9 @@ class BaseCalculationManager(ABC):
         self.to_submit = to_submit
         self.primitive = primitive
         self.job_manager = JobManager(
-            calc_path=self.calc_path, ignore_personal_errors=ignore_personal_errors
+            calc_path=self.calc_path,
+            manager_name=f"{self.material_name} {self.mode.upper()}",
+            ignore_personal_errors=ignore_personal_errors,
         )
 
         self.from_scratch = from_scratch

--- a/vasp_manager/calculation_manager/bulkmod.py
+++ b/vasp_manager/calculation_manager/bulkmod.py
@@ -119,8 +119,8 @@ class BulkmodCalculationManager(BaseCalculationManager):
         """
         if not self.from_relax:
             msg = (
-                "Running bulk modulus calculation without previous relaxation"
-                "\n\t starting structure must be fairly close to equilibrium volume!"
+                "Running bulk modulus calculation without previous relaxation\n"
+                "\tStarting structure must be fairly close to equilibrium volume!"
             )
             self.logger.warning(msg)
 
@@ -171,8 +171,8 @@ class BulkmodCalculationManager(BaseCalculationManager):
                     msg = (
                         f"{self.mode.upper()} Calculation: "
                         "Couldn't address all VASP Errors\n"
+                        f"\tVASP Errors: {vasp_errors}\n"
                         "\tRefusing to continue...\n"
-                        f"\tVasp Errors: {vasp_errors}\n"
                     )
                     self.logger.error(msg)
                     self.stop()

--- a/vasp_manager/calculation_manager/bulkmod.py
+++ b/vasp_manager/calculation_manager/bulkmod.py
@@ -204,6 +204,8 @@ class BulkmodCalculationManager(BaseCalculationManager):
         try:
             ba = BulkmodAnalyzer(calc_path=self.calc_path)
             self._results = ba.results
+            self.logger.info(f"{self.mode.upper()} Calculation: Success")
+            self.logger.info(f"BULK MODULUS: {ba.results.get('B')}")
         except Exception as e:
             self.logger.warning(e)
             self._results = None

--- a/vasp_manager/calculation_manager/elastic.py
+++ b/vasp_manager/calculation_manager/elastic.py
@@ -1,12 +1,13 @@
 # Copyright (c) Dale Gaines II
 # Distributed under the terms of the MIT LICENSE
 
+import json
 import logging
 from functools import cached_property
 
 from vasp_manager.analyzer import ElasticAnalyzer
 from vasp_manager.calculation_manager.base import BaseCalculationManager
-from vasp_manager.utils import LoggerAdapter, pgrep, ptail
+from vasp_manager.utils import LoggerAdapter, NumpyEncoder, pgrep, ptail
 from vasp_manager.vasp_input_creator import VaspInputCreator
 
 logger = logging.getLogger(__name__)
@@ -189,4 +190,7 @@ class ElasticCalculationManager(BaseCalculationManager):
         Gets results from elastic calculation
         """
         ea = ElasticAnalyzer.from_calc_dir(self.calc_path)
+        if ea.results.get("elastically_unstable"):
+            self.logger.warning("-" * 10 + " WARNING: Elastically Unstable " + "-" * 10)
+        self.logger.debug(json.dumps(ea.results, cls=NumpyEncoder, indent=2))
         return ea.results

--- a/vasp_manager/calculation_manager/elastic.py
+++ b/vasp_manager/calculation_manager/elastic.py
@@ -129,8 +129,8 @@ class ElasticCalculationManager(BaseCalculationManager):
                 msg = (
                     f"{self.mode.upper()} Calculation: "
                     "Couldn't address all VASP Errors\n"
+                    f"\tVASP Errors: {vasp_errors}\n"
                     "\tRefusing to continue...\n"
-                    f"\tVasp Errors: {vasp_errors}\n"
                 )
                 self.logger.error(msg)
                 self.stop()

--- a/vasp_manager/calculation_manager/rlx.py
+++ b/vasp_manager/calculation_manager/rlx.py
@@ -134,8 +134,8 @@ class RlxCalculationManager(BaseCalculationManager):
                 msg = (
                     f"{self.mode.upper()} Calculation: "
                     "Couldn't address all VASP Errors\n"
+                    f"\tVASP Errors: {vasp_errors}\n"
                     "\tRefusing to continue...\n"
-                    f"\tVasp Errors: {vasp_errors}\n"
                 )
                 self.logger.error(msg)
                 self.stop()
@@ -156,7 +156,7 @@ class RlxCalculationManager(BaseCalculationManager):
             if len(archive_dirs) >= self.max_reruns - 1:
                 msg = (
                     "Many archives exist, calculations may not be converging\n"
-                    "\t Refusing to continue..."
+                    "\tRefusing to continue..."
                 )
                 self.logger.error(msg)
                 return False
@@ -207,22 +207,22 @@ class RlxCalculationManager(BaseCalculationManager):
                 contcar_path, return_spacegroup=True
             )
         except Exception as e:
-            self.logger.error(f"  RLX CONTCAR doesn't exist or is empty: {e}")
+            self.logger.error(f"RLX CONTCAR doesn't exist or is empty: {e}")
             return False
 
         if orig_spacegroup == c_spacegroup:
             self.logger.debug(
-                f"  Spacegroups match orig-{orig_spacegroup} == rlx-{c_spacegroup}"
+                f"Spacegroups match orig-{orig_spacegroup} == rlx-{c_spacegroup}"
             )
         else:
             self.logger.warning(
-                "   Warning: spacegroups do not match "
+                "Warning: spacegroups do not match "
                 + f"orig-{orig_spacegroup} != rlx-{c_spacegroup}"
             )
 
         volume_diff = (c_structure.volume - p_structure.volume) / p_structure.volume
         if np.abs(volume_diff) >= 0.05:
-            self.logger.warning(f"  NEED TO RE-RELAX: dV = {volume_diff:.4f}")
+            self.logger.warning(f"NEED TO RE-RELAX: dV = {volume_diff:.4f}")
             volume_converged = False
             previous_magmom_per_atom = self._parse_magmom_per_atom()
             if previous_magmom_per_atom is None:
@@ -232,8 +232,8 @@ class RlxCalculationManager(BaseCalculationManager):
             if self.to_rerun:
                 self.setup_calc(make_archive=True, use_spin=use_spin)
         else:
-            self.logger.info("  RLX volume converged")
-            self.logger.debug(f"  dV = {volume_diff:.4f}")
+            self.logger.info("RLX volume converged")
+            self.logger.debug(f"dV = {volume_diff:.4f}")
             volume_converged = True
         orig_volume_diff = (
             c_structure.volume - orig_structure.volume

--- a/vasp_manager/calculation_manager/rlx_coarse.py
+++ b/vasp_manager/calculation_manager/rlx_coarse.py
@@ -5,7 +5,7 @@ import logging
 from functools import cached_property
 
 from vasp_manager.calculation_manager.base import BaseCalculationManager
-from vasp_manager.utils import pgrep, ptail
+from vasp_manager.utils import LoggerAdapter, pgrep, ptail
 from vasp_manager.vasp_input_creator import VaspInputCreator
 
 logger = logging.getLogger(__name__)
@@ -46,6 +46,7 @@ class RlxCoarseCalculationManager(BaseCalculationManager):
         )
         self._is_done = None
         self._results = None
+        self.logger = LoggerAdapter(logging.getLogger(__name__), self.material_name)
 
     @cached_property
     def mode(self):
@@ -97,7 +98,7 @@ class RlxCoarseCalculationManager(BaseCalculationManager):
             relaxation_successful (bool): if True, relaxation completed successfully
         """
         if not self.job_complete:
-            logger.info(f"{self.mode.upper()} not finished")
+            self.self.logger.info(f"{self.mode.upper()} not finished")
             return False
 
         stdout_path = self.calc_path / "stdout.txt"
@@ -105,7 +106,7 @@ class RlxCoarseCalculationManager(BaseCalculationManager):
             # calculation never actually ran
             # shouldn't get here unless function was called with submit=False
             # or job was manually cancelled
-            logger.info(f"{self.mode.upper()} Calculation: No stdout.txt available")
+            self.logger.info(f"{self.mode.upper()} Calculation: No stdout.txt available")
             if self.to_rerun:
                 self._cancel_previous_job()
                 self.setup_calc()
@@ -116,7 +117,7 @@ class RlxCoarseCalculationManager(BaseCalculationManager):
             all_errors_addressed = self._address_vasp_errors(vasp_errors)
             if all_errors_addressed:
                 if self.to_rerun:
-                    logger.info(f"Rerunning {self.calc_path}")
+                    self.logger.info(f"Rerunning {self.calc_path}")
                     self.setup_calc(make_archive=True)
             else:
                 msg = (
@@ -125,7 +126,7 @@ class RlxCoarseCalculationManager(BaseCalculationManager):
                     "\tRefusing to continue...\n"
                     f"\tVasp Errors: {vasp_errors}\n"
                 )
-                logger.error(msg)
+                self.logger.error(msg)
                 self.stop()
             return False
 
@@ -136,21 +137,21 @@ class RlxCoarseCalculationManager(BaseCalculationManager):
         if len(grep_output) == 0:
             archive_dirs = list(self.calc_path.glob("archive*"))
             if len(archive_dirs) >= self.max_reruns - 1:
-                logger.warning(
+                self.logger.warning(
                     "Many archives exist, continuing to force based relaxation..."
                 )
                 return True
 
-            logger.warning(f"{self.mode.upper()} FAILED")
-            logger.debug(tail_output)
+            self.logger.warning(f"{self.mode.upper()} FAILED")
+            self.logger.debug(tail_output)
             if self.to_rerun:
-                logger.info(f"Rerunning {self.calc_path}")
+                self.logger.info(f"Rerunning {self.calc_path}")
                 # increase nodes as its likely the calculation failed
                 self.setup_calc(increase_walltime_by_factor=2, make_archive=True)
             return False
 
-        logger.info(f"{self.mode.upper()} Calculation: reached required accuracy")
-        logger.debug(tail_output)
+        self.logger.info(f"{self.mode.upper()} Calculation: reached required accuracy")
+        self.logger.debug(tail_output)
         return True
 
     @property

--- a/vasp_manager/calculation_manager/rlx_coarse.py
+++ b/vasp_manager/calculation_manager/rlx_coarse.py
@@ -123,8 +123,8 @@ class RlxCoarseCalculationManager(BaseCalculationManager):
                 msg = (
                     f"{self.mode.upper()} Calculation: "
                     "Couldn't address all VASP Errors\n"
+                    f"\tVASP Errors: {vasp_errors}\n"
                     "\tRefusing to continue...\n"
-                    f"\tVasp Errors: {vasp_errors}\n"
                 )
                 self.logger.error(msg)
                 self.stop()

--- a/vasp_manager/calculation_manager/rlx_coarse.py
+++ b/vasp_manager/calculation_manager/rlx_coarse.py
@@ -98,7 +98,7 @@ class RlxCoarseCalculationManager(BaseCalculationManager):
             relaxation_successful (bool): if True, relaxation completed successfully
         """
         if not self.job_complete:
-            self.self.logger.info(f"{self.mode.upper()} not finished")
+            self.logger.info(f"{self.mode.upper()} not finished")
             return False
 
         stdout_path = self.calc_path / "stdout.txt"

--- a/vasp_manager/calculation_manager/static.py
+++ b/vasp_manager/calculation_manager/static.py
@@ -135,8 +135,8 @@ class StaticCalculationManager(BaseCalculationManager):
                 msg = (
                     f"{self.mode.upper()} Calculation: "
                     "Couldn't address all VASP Errors\n"
+                    f"\tVASP Errors: {vasp_errors}\n"
                     "\tRefusing to continue...\n"
-                    f"\tVasp Errors: {vasp_errors}\n"
                 )
                 self.logger.error(msg)
                 self.stop()

--- a/vasp_manager/job_manager.py
+++ b/vasp_manager/job_manager.py
@@ -105,9 +105,11 @@ class JobManager:
             return True
 
         if "personal" in self.computer:
-            error_msg = f"Cannot submit {self.mode.upper()} job for on personal computer"
-            error_msg += "\n\tIgnoring job submission..."
-            logger.debug(error_msg)
+            msg = (
+                f"Cannot submit {self.mode.upper()} job for on personal computer\n"
+                "\tIgnoring job submission..."
+            )
+            logger.debug(msg)
             return True
 
         qpath = self.calc_path / self.exe_name
@@ -141,9 +143,8 @@ class JobManager:
     def _check_job_complete(self):
         """Returns True if job done"""
         if self.computer == "personal":
-            error_msg = "Cannot check job on personal computer"
-            error_msg += "\n\tIgnoring job status check..."
-            logger.debug(error_msg)
+            msg = "Cannot check job on personal computer\n\tIgnoring job status check..."
+            logger.debug(msg)
             # This enables job resubmission by letting the calling function
             # continue anyways
             return True

--- a/vasp_manager/job_manager.py
+++ b/vasp_manager/job_manager.py
@@ -101,7 +101,7 @@ class JobManager:
         Submits job, making sure to not make duplicate jobs
         """
         if self.job_exists:
-            logger.info(f"{self.mode.upper()} Job already exists")
+            logger.info(f"{self.mode.upper()} job already exists")
             return True
 
         if "personal" in self.computer:

--- a/vasp_manager/job_manager.py
+++ b/vasp_manager/job_manager.py
@@ -7,7 +7,7 @@ import subprocess
 from functools import cached_property
 from pathlib import Path
 
-from vasp_manager.utils import change_directory
+from vasp_manager.utils import LoggerAdapter, change_directory
 
 logger = logging.getLogger(__name__)
 
@@ -23,14 +23,16 @@ class JobManager:
         exe_name="vasp.q",
         jobid_name="jobid",
         config_path=None,
+        manager_name=None,
         ignore_personal_errors=True,
     ):
         """
         Args:
             calc_path (str | Path): base directory of job
-            config_path (str | Path): path to configuration files
             exe_name (str): filename for slurm job submission
             jobid_name (str): filename for storing slurm jobid
+            config_path (str | Path): path to configuration files
+            manager_name (str): name for logging purposes
             ignore_personal_errors (bool): if True, ignore job submission errors
                 if on personal computer
         """
@@ -41,8 +43,10 @@ class JobManager:
         self.ignore_personal_errors = ignore_personal_errors
         self.exe_name = exe_name
         self.jobid_name = jobid_name
+        self.manager_name = manager_name if manager_name else str(calc_path)
         self._jobid = None
         self._job_complete = None
+        self.logger = LoggerAdapter(logging.getLogger(__name__), self.manager_name)
 
     @property
     def computing_config_dict(self):
@@ -101,7 +105,7 @@ class JobManager:
         Submits job, making sure to not make duplicate jobs
         """
         if self.job_exists:
-            logger.info(f"{self.mode.upper()} job already exists")
+            self.logger.info(f"{self.mode.upper()} job already exists")
             return True
 
         if "personal" in self.computer:
@@ -109,12 +113,12 @@ class JobManager:
                 f"Cannot submit {self.mode.upper()} job for on personal computer\n"
                 "\tIgnoring job submission..."
             )
-            logger.debug(msg)
+            self.logger.debug(msg)
             return True
 
         qpath = self.calc_path / self.exe_name
         if not qpath.exists():
-            logger.info(f"No {self.exe_name} file in {self.calc_path}")
+            self.logger.info(f"No {self.exe_name} file in {self.calc_path}")
             # return False here instead of catching an exception
             # This enables job resubmission by letting the calling function
             # know that the calculation needs to be restarted
@@ -131,7 +135,7 @@ class JobManager:
             self.jobid = jobid
             with open(self.jobid_name, "w+") as fw:
                 fw.write(f"{jobid}\n")
-        logger.info(f"Submitted job {jobid}")
+        self.logger.info(f"Submitted job {jobid}")
         return True
 
     @property
@@ -144,7 +148,7 @@ class JobManager:
         """Returns True if job done"""
         if self.computer == "personal":
             msg = "Cannot check job on personal computer\n\tIgnoring job status check..."
-            logger.debug(msg)
+            self.logger.debug(msg)
             # This enables job resubmission by letting the calling function
             # continue anyways
             return True

--- a/vasp_manager/utils.py
+++ b/vasp_manager/utils.py
@@ -3,6 +3,7 @@
 
 import gzip
 import json
+import logging
 import os
 from collections import deque
 from contextlib import contextmanager
@@ -34,6 +35,15 @@ class NumpyEncoder(json.JSONEncoder):
         elif isinstance(obj, np.ndarray):
             return obj.tolist()
         return json.JSONEncoder.default(self, obj)
+
+
+class LoggerAdapter(logging.LoggerAdapter):
+    def __init__(self, logger, prefix):
+        super(LoggerAdapter, self).__init__(logger, {})
+        self.prefix = prefix
+
+    def process(self, msg, kwargs):
+        return f"[{self.prefix}] {msg}", kwargs
 
 
 def get_pmg_structure_from_poscar(

--- a/vasp_manager/utils.py
+++ b/vasp_manager/utils.py
@@ -38,12 +38,13 @@ class NumpyEncoder(json.JSONEncoder):
 
 
 class LoggerAdapter(logging.LoggerAdapter):
-    def __init__(self, logger, prefix):
+    def __init__(self, logger, prefix, separator=" -- "):
         super(LoggerAdapter, self).__init__(logger, {})
         self.prefix = prefix
+        self.separator = separator
 
     def process(self, msg, kwargs):
-        return f"[{self.prefix}] {msg}", kwargs
+        return f"{self.prefix}{self.separator}{msg}", kwargs
 
 
 def get_pmg_structure_from_poscar(


### PR DESCRIPTION
Each manager should now print the material name when logging, which should make things easier to track when using multiprocessing.