### PR TITLE
Update number of significant figures for POSCAR writing

### DIFF
--- a/vasp_manager/vasp_input_creator.py
+++ b/vasp_manager/vasp_input_creator.py
@@ -41,7 +41,7 @@ class VaspInputCreator:
         name=None,
         increase_nodes_by_factor=1,
         increase_walltime_by_factor=1,
-        poscar_significant_figures=8,
+        poscar_significant_figures=16,
         ncore_per_node_for_memory=None,
         use_spin=True,
     ):


### PR DESCRIPTION
In very, very rare cases, it turns out that rounding the significant figures to 8 instead of 16 will break the symmetry of the cell. I've only hit this issue for certain R-3c cells, so I imagine this has something to do with their irrational symmetry operations and floating point precision.