### PR TITLE
Migrate from black/flake8/isort to ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,19 +14,9 @@ repos:
         args: [--unsafe]
       - id: check-merge-conflict
 
-  - repo: https://github.com/psf/black
-    rev: 22.3.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.14.14
     hooks:
-      - id: black
-
-  - repo: https://github.com/john-hen/Flake8-pyproject
-    rev: 1.1.0
-    hooks:
-      - id: Flake8-pyproject
-        name: flake8
-        exclude: ^vasp_manager/tests
-
-  - repo: https://github.com/timothycrosley/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
+      - id: ruff-check
+        args: [--fix]
+      - id: ruff-format

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
 ## [Unreleased]
 
 ### Added
@@ -15,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `VaspInputCreator` and `JobManager` now use shared cached config loaders instead of reading JSON on each instantiation
 - Add `develop` branch to CI pull request trigger
+- Migrate from black/flake8/isort to ruff
 
 
 ## [1.4.2] - 2025-11-13

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,12 +29,11 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "black",
     "coverage",
-    "isort",
     "pre-commit",
     "pytest",
     "mypy",
+    "ruff",
 ]
 docs = [
     "blacken-docs>=1.16.0",
@@ -48,38 +47,20 @@ docs = [
 [project.urls]
 repository = "https://github.com/dgaines2/vasp_manager"
 
-[tool.black]
-target-version = ["py310"]
+[tool.ruff]
+target-version = "py310"
 line-length = 90
-include = '\.pyi?$'
-exclude = '''
-/(
-    \.git
-  | \.hg
-  | \.mypy_cache
-  | \.tox
-  | \.venv
-  | _build
-  | build
-  | dist
-)/
-| tests/data
-'''
 
-[tool.isort]
-profile = "black"
-multi_line_output = 3
-include_trailing_comma = true
-force_grid_wrap = 0
-use_parentheses = true
-line_length = 90
+[tool.ruff.lint]
+select = ["E", "F", "W", "I"]
+ignore = ["E203", "E231"]
 
-[tool.flake8]
-max-line-length = 90
-exclude = "vasp_manager/tests/ | **/*.pyc | .git | __pycache__"
-per-file-ignores = "__init__.py:F401"
-select = "E, F, W, B9"
-ignore = "E203, W503"
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401"]
+"vasp_manager/tests/test_utils.py" = ["E501"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["vasp_manager"]
 
 [tool.pytest.ini_options]
 pythonpath = "."

--- a/vasp_manager/analyzer/elastic_analyzer.py
+++ b/vasp_manager/analyzer/elastic_analyzer.py
@@ -49,11 +49,11 @@ class ElasticAnalyzer:
         values = np.asarray(values)
         if values.shape != (6, 6):
             raise ValueError(
-                "cij must be a 6x6 array," f"found shape={values.shape} instead"
+                f"cij must be a 6x6 array,found shape={values.shape} instead"
             )
         if values.dtype != float:
             raise TypeError(
-                "cij must be a 6x6 array of floats," f" found type={values.dtype} instead"
+                f"cij must be a 6x6 array of floats, found type={values.dtype} instead"
             )
         self._cij = values
 

--- a/vasp_manager/tests/test_analyzers.py
+++ b/vasp_manager/tests/test_analyzers.py
@@ -37,7 +37,7 @@ def test_elastic_analyzer_stable(stable_material_dir):
     assert results["G_Reuss"] == 14.286
     assert results["G_Voigt"] == 14.734
     assert results["G_VRH"] == 14.51
-    assert results["unstable"] == False
+    assert not results["unstable"]
     assert np.array_equal(
         results["elastic_tensor"],
         [
@@ -71,7 +71,7 @@ def test_elastic_analyzer_unstable(unstable_material_dir):
     assert results["G_Reuss"] == -199.401
     assert results["G_Voigt"] == 25.595
     assert results["G_VRH"] == -86.903
-    assert results["unstable"] == True
+    assert results["unstable"]
     assert np.array_equal(
         results["elastic_tensor"],
         [

--- a/vasp_manager/tests/test_calculation_managers.py
+++ b/vasp_manager/tests/test_calculation_managers.py
@@ -1,6 +1,3 @@
-import filecmp
-
-import pytest
 from pymatgen.analysis.structure_matcher import StructureMatcher
 from pymatgen.core import Structure
 
@@ -79,7 +76,7 @@ def test_static_results(calcs_dir):
     assert static_manager.is_done
     assert static_manager.results["final_energy"] == -6.7778924
     assert static_manager.results["final_energy_pa"] == -3.3889462
-    assert static_manager.results["magmom_pa"] == None
+    assert static_manager.results["magmom_pa"] is None
 
 
 def test_static_spin_results(calcs_dir):
@@ -370,7 +367,7 @@ def test_rlx_archive(calcs_dir):
         magmom_per_atom_cutoff=1.0,
     )
     assert not rlx_manager.is_done
-    assert rlx_manager.results == None
+    assert rlx_manager.results is None
     assert not rlx_manager.vasp_input_creator.use_spin
     # check archive made correctly
     archive_dir = rlx_dir / "archive_0"
@@ -397,7 +394,7 @@ def test_static_rerun(calcs_dir):
         to_submit=False,
     )
     assert not static_manager.is_done
-    assert static_manager.results == None
+    assert static_manager.results is None
     static_dir_files = list(static_dir.glob("*"))
     assert len(static_dir_files) == 4
     for file in static_dir_files:
@@ -417,7 +414,7 @@ def test_bulkmod_rerun(calcs_dir):
         to_submit=False,
     )
     assert not bulkmod_manager.is_done
-    assert bulkmod_manager.results == None
+    assert bulkmod_manager.results is None
 
     bulkmod_dir_contents = list(bulkmod_dir.glob("*"))
     bulkmod_dir_files = [f for f in bulkmod_dir_contents if f.is_file()]
@@ -447,4 +444,4 @@ def test_elastic_rerun(calcs_dir):
         to_submit=False,
     )
     assert not elastic_manager.is_done
-    assert elastic_manager.results == None
+    assert elastic_manager.results is None

--- a/vasp_manager/tests/test_job_manager.py
+++ b/vasp_manager/tests/test_job_manager.py
@@ -3,8 +3,6 @@
 
 import json
 
-import pytest
-
 from vasp_manager.job_manager import JobManager
 
 

--- a/vasp_manager/vasp_input_creator.py
+++ b/vasp_manager/vasp_input_creator.py
@@ -112,7 +112,7 @@ class VaspInputCreator:
     def source_structure(self) -> Structure:
         num_archives = len(list(self.calc_dir.glob("archive*")))
         if num_archives > 0:
-            archive_name = f"archive_{num_archives-1}"
+            archive_name = f"archive_{num_archives - 1}"
             self.poscar_source_path = self.calc_dir / archive_name / "CONTCAR"
         try:
             structure = get_pmg_structure_from_poscar(

--- a/vasp_manager/vasp_manager.py
+++ b/vasp_manager/vasp_manager.py
@@ -55,9 +55,7 @@ ASCII_LOGO = r"""
      \/ \__,_|___/ .__/|_|  |_|\__,_|_| |_|\__,_|\__, |\___|_|
                  | |                              __/ |
                  |_|                             |___/ v{}
-""".format(
-    version("vasp_manager")
-)
+""".format(version("vasp_manager"))
 
 
 class VaspManager:
@@ -459,7 +457,9 @@ class VaspManager:
         else:
             results = []
             for i, material_name in enumerate(self.material_names):
-                print(f"{i+1}/{len(self.material_names)} -- {material_name}", flush=True)
+                print(
+                    f"{i + 1}/{len(self.material_names)} -- {material_name}", flush=True
+                )
                 results.append(self._manage_calculations(material_name))
                 print()
         return results


### PR DESCRIPTION
Replace three separate linting/formatting tools with ruff for faster, unified code quality checks. Update pre-commit hooks, pyproject.toml config, and fix lint violations in tests (E711, E712 comparisons).