### PR TITLE
Rerun resource kwargs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add typed pydantic config models (`CalcConfig`, `ComputingConfig`) with cached loaders
 - Add `VaspRun` class that owns run-level concerns (error checking, magmom parsing)
+- Add configurable job resource parameters (`atoms_per_node`, `rerun_increase`, `rerun_increase_factor`) to `ComputingConfig`
+- Add smart rerun diagnosis: relaxations distinguish "completed all NSW without converging" (relaunch same params) from "timed out" (apply rerun strategy)
 
 ### Changed
 
@@ -25,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Job naming (`pad_string`) extracted from `VaspInputCreator` into each `CalculationManager` via `job_prefix`
 - Move `job_prefix` abstract property to `BaseCalculationManager` for SLURM job naming
 - Bulkmod strains are now independent jobs, each with their own `VaspRun`, `VaspInputCreator`, and `JobManager`
+- Bulkmod handles per-strain failures individually instead of restarting from scratch
 
 ### Removed
 

--- a/calculations/computing_config.json
+++ b/calculations/computing_config.json
@@ -17,7 +17,10 @@
     "allocation": "p31151",
     "vasp_module": "vasp/6.4.3-openmpi-intel-hdf5-cpu-only",
     "ncore": 12,
-    "ncore_per_node": 52
+    "ncore_per_node": 52,
+    "atoms_per_node": 16,
+    "rerun_increase": "walltime",
+    "rerun_increase_factor": 2
   },
   "perlmutter": {
     "user_id": "dwg4898",
@@ -28,6 +31,9 @@
     "vasp_module": "vasp/6.4.3-cpu",
     "ncore": 16,
     "ncore_per_node": 128
+    "atoms_per_node": 32,
+    "rerun_increase": "nodes",
+    "rerun_increase_factor": 2
   },
   "bridges2": {
     "user_id": "daleg",
@@ -37,5 +43,8 @@
     "vasp_module": "",
     "ncore": 16,
     "ncore_per_node": 128
+    "atoms_per_node": 32,
+    "rerun_increase": "nodes",
+    "rerun_increase_factor": 2
   }
 }

--- a/docs/user/setting_up.md
+++ b/docs/user/setting_up.md
@@ -45,6 +45,9 @@ running jobs on.
 * `vasp_module` (str)
 * `ncore` (int)
 * `ncore_per_node` (int)
+* `atoms_per_node` (int, optional) — default `32`
+* `rerun_increase` (str, optional) — `"nodes"` or `"walltime"`, default `"walltime"`
+* `rerun_increase_factor` (int, optional) — default `2`
 
 !!! note
 
@@ -55,6 +58,18 @@ running jobs on.
     * For `vasp_module`, a VASP 6 module is strongly recommended.
     * The `personal` "computer" is only used for internal unit testing, not to
       run any actual jobs.
+
+!!! note "Job resource tuning"
+
+    The following fields are **optional** — omitting them preserves the previous
+    default behavior.
+
+    * `atoms_per_node` controls how many compute nodes are requested per job
+      (nodes = floor(total atoms / `atoms_per_node`) + 1).
+    * `rerun_increase` chooses which resource to scale when a job times out:
+      `"walltime"` (increase the walltime) or `"nodes"` (increase the node count).
+    * `rerun_increase_factor` is the multiplier applied to the chosen resource
+      on rerun (e.g., `2` means double).
 
 !!! warning "Warning"
 
@@ -89,8 +104,9 @@ For each desired calculation mode, set the INCAR tags in this json.
   [Spin Configuration](user_config/spin.md)
 * See more about DFT+U settings (`"hubbards": "wang"`) here:
   [DFT+U Configuration](user_config/hubbards.md)
-* Note: `VaspManager` uses 1 compute node per 32 atoms, so don't be surprised
-  if you job requests more than a single node.
+* Note: `VaspManager` uses 1 compute node per `atoms_per_node` atoms (see
+  [Computing Configuration](#computing-configuration)), so don't be surprised
+  if your job requests more than a single node.
 
 ### Supported tags:
 
@@ -130,8 +146,10 @@ For each desired calculation mode, set the INCAR tags in this json.
       them from being parsed as decimals (e.g. `0.001`).
     * `walltime` should be passed as `"hh:mm:ss"`. You should try to set this
       such that your job hits NSW before it runs out of time.  If your job
-      fails or times out, an archive will be made and the calculation will be
-      resubmitted with a (2x) longer walltime.
+      times out, an archive will be made and the calculation will be
+      resubmitted with increased resources according to `rerun_increase` and
+      `rerun_increase_factor` in your
+      [computing configuration](#computing-configuration).
     * You can place another `calc_config.json` file in a specific material's calculation
       directory (e.g. `NaCl/rlx`) to use custom settings for only that
       material. You only need to include settings you want to change from the

--- a/vasp_manager/calculation_manager/base.py
+++ b/vasp_manager/calculation_manager/base.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 
 from pymatgen.core import Structure
 
+from vasp_manager.config import load_computing_config
 from vasp_manager.job_manager import JobManager
 from vasp_manager.utils import get_pmg_structure_from_poscar
 from vasp_manager.vasp_input_creator import VaspInputCreator
@@ -97,6 +98,17 @@ class BaseCalculationManager(ABC):
     @abstractmethod
     def check_calc(self) -> bool:
         pass
+
+    def _rerun_resource_kwargs(self) -> dict[str, int]:
+        """Build increase_*_by_factor kwargs for a timeout rerun.
+
+        Reads the rerun strategy from computing_config to determine whether
+        to increase nodes or walltime, and by what factor.
+        """
+        cc = load_computing_config(self.config_dir)
+        if cc.rerun_increase == "nodes":
+            return {"increase_nodes_by_factor": cc.rerun_increase_factor}
+        return {"increase_walltime_by_factor": cc.rerun_increase_factor}
 
     def _load_structure(self, poscar_path: Path | None = None) -> Structure:
         """

--- a/vasp_manager/calculation_manager/bulkmod.py
+++ b/vasp_manager/calculation_manager/bulkmod.py
@@ -164,6 +164,64 @@ class BulkmodCalculationManager(BaseCalculationManager):
             use_spin = True
         return use_spin
 
+    def _setup_strain(
+        self,
+        strain_index: int,
+        increase_nodes_by_factor: int = 1,
+        increase_walltime_by_factor: int = 1,
+    ) -> VaspRun:
+        """Create input files for a single strain and return its VaspRun."""
+        strain = self.strains[strain_index]
+        strain_name = self.strain_names[strain_index]
+        strain_dir = self.calc_dir / strain_name
+        self.logger.info(strain_dir)
+
+        if not strain_dir.exists():
+            strain_dir.mkdir()
+
+        base_structure = self._load_structure()
+        use_spin = self._check_use_spin()
+        strained = base_structure.copy()
+        strained.scale_lattice(base_structure.volume * strain**3)
+
+        vic = VaspInputCreator(
+            calc_dir=strain_dir,
+            mode="static",
+            structure=strained,
+            config_dir=self.config_dir,
+            name=f"{self.material_name}_s{strain_name.split('_')[1]}",
+            job_prefix=self.job_prefix,
+            increase_nodes_by_factor=increase_nodes_by_factor,
+            increase_walltime_by_factor=increase_walltime_by_factor,
+            use_spin=use_spin,
+        )
+        vic.create()
+
+        jm = JobManager(
+            calc_dir=strain_dir,
+            manager_name=f"{self.material_name} BULKMOD {strain_name}",
+            config_dir=self.config_dir,
+            ignore_personal_errors=self._ignore_personal_errors,
+        )
+
+        return VaspRun(
+            run_dir=strain_dir,
+            structure=strained,
+            vasp_input_creator=vic,
+            job_manager=jm,
+        )
+
+    def _clean_strain(self, strain_name: str) -> None:
+        """Remove a single strain directory and cancel its job."""
+        strain_dir = self.calc_dir / strain_name
+        jobid_path = strain_dir / "jobid"
+        if jobid_path.exists():
+            with open(jobid_path) as fr:
+                jobid = fr.read().strip()
+            os.system(f"scancel {jobid}")
+        if strain_dir.exists():
+            shutil.rmtree(strain_dir)
+
     def setup_calc(
         self,
         increase_nodes_by_factor: int = 1,
@@ -182,49 +240,15 @@ class BulkmodCalculationManager(BaseCalculationManager):
         if not self.calc_dir.exists():
             self.calc_dir.mkdir()
 
-        base_structure = self._load_structure()
-        use_spin = self._check_use_spin()
-        runs: dict[str, VaspRun] = {}
-
         self.logger.info("Making strain directories")
-        for i, strain in enumerate(self.strains):
-            strain_name = self.strain_names[i]
-            strain_dir = self.calc_dir / strain_name
-            self.logger.info(strain_dir)
-
-            if not strain_dir.exists():
-                strain_dir.mkdir()
-
-            # Scale structure for this strain
-            strained = base_structure.copy()
-            strained.scale_lattice(base_structure.volume * strain**3)
-
-            vic = VaspInputCreator(
-                calc_dir=strain_dir,
-                mode="static",
-                structure=strained,
-                config_dir=self.config_dir,
-                name=f"{self.material_name}_s{strain_name.split('_')[1]}",
-                job_prefix=self.job_prefix,
+        runs: dict[str, VaspRun] = {}
+        for i in range(len(self.strains)):
+            run = self._setup_strain(
+                i,
                 increase_nodes_by_factor=increase_nodes_by_factor,
                 increase_walltime_by_factor=increase_walltime_by_factor,
-                use_spin=use_spin,
             )
-            vic.create()
-
-            jm = JobManager(
-                calc_dir=strain_dir,
-                manager_name=f"{self.material_name} BULKMOD {strain_name}",
-                config_dir=self.config_dir,
-                ignore_personal_errors=self._ignore_personal_errors,
-            )
-
-            runs[strain_name] = VaspRun(
-                run_dir=strain_dir,
-                structure=strained,
-                vasp_input_creator=vic,
-                job_manager=jm,
-            )
+            runs[self.strain_names[i]] = run
 
         self._vasp_runs = runs
 
@@ -244,19 +268,24 @@ class BulkmodCalculationManager(BaseCalculationManager):
             self.logger.info(f"{self.mode.upper()} job not finished")
             return False
 
-        for strain_name, run in self.vasp_runs.items():
+        all_passed = True
+        for i, (strain_name, run) in enumerate(self.vasp_runs.items()):
             stdout_path = run.run_dir / "stdout.txt"
             if not stdout_path.exists():
-                return False
+                all_passed = False
+                continue
 
             vasp_errors = run.check_vasp_errors(extra_errors=["NELM"])
             if len(vasp_errors) > 0:
                 all_errors_addressed = run.address_vasp_errors(vasp_errors)
                 if all_errors_addressed:
                     if self.to_rerun:
-                        self.logger.info(f"Rerunning {self.calc_dir}")
-                        self._from_scratch()
-                        self.setup_calc()
+                        self.logger.info(f"Rerunning {strain_name}")
+                        self._clean_strain(strain_name)
+                        new_run = self._setup_strain(i)
+                        self._vasp_runs[strain_name] = new_run
+                        if self.to_submit:
+                            new_run.job_manager.submit_job()
                 else:
                     msg = (
                         f"{self.mode.upper()} Calculation: "
@@ -266,17 +295,21 @@ class BulkmodCalculationManager(BaseCalculationManager):
                     )
                     self.logger.error(msg)
                     self.stop()
-                return False
+                all_passed = False
+                continue
 
             grep_output = pgrep(stdout_path, "1 F=", stop_after_first_match=True)
             if len(grep_output) == 0:
                 if self.to_rerun:
-                    self.logger.info(f"Rerunning {self.calc_dir}")
-                    # increase nodes as its likely the calculation failed
-                    self._from_scratch()
-                    self.setup_calc(increase_walltime_by_factor=2)
-                return False
-        return True
+                    self.logger.info(f"Rerunning {strain_name}")
+                    self._clean_strain(strain_name)
+                    new_run = self._setup_strain(i, **self._rerun_resource_kwargs())
+                    self._vasp_runs[strain_name] = new_run
+                    if self.to_submit:
+                        new_run.job_manager.submit_job()
+                all_passed = False
+                continue
+        return all_passed
 
     @property
     def is_done(self) -> bool:

--- a/vasp_manager/calculation_manager/elastic.py
+++ b/vasp_manager/calculation_manager/elastic.py
@@ -163,9 +163,8 @@ class ElasticCalculationManager(BaseCalculationManager):
             self.logger.info(f"{self.mode.upper()} Calculation: FAILED")
             if self.to_rerun:
                 self.logger.info(f"Rerunning {self.calc_dir}")
-                # increase walltime as its likely the calculation failed
                 self._from_scratch()
-                self.setup_calc(increase_walltime_by_factor=2)
+                self.setup_calc(**self._rerun_resource_kwargs())
             return False
 
         self.logger.info(f"{self.mode.upper()} Calculation: Success")

--- a/vasp_manager/calculation_manager/rlx.py
+++ b/vasp_manager/calculation_manager/rlx.py
@@ -175,10 +175,18 @@ class RlxCalculationManager(BaseCalculationManager):
             self.logger.debug(tail_output)
             if self.to_rerun:
                 self.logger.info(f"Rerunning {self.calc_dir}")
-                # increase nodes as its likely the calculation failed
-                self.setup_calc(
-                    increase_walltime_by_factor=2, make_archive=True, use_spin=use_spin
-                )
+                nsw = self.vasp_input_creator.calc_config.nsw
+                completed_steps = len(pgrep(stdout_path, "F="))
+                if completed_steps >= nsw:
+                    # ran all NSW steps without converging — relaunch same params
+                    self.setup_calc(make_archive=True, use_spin=use_spin)
+                else:
+                    # timed out before completing NSW — apply rerun strategy
+                    self.setup_calc(
+                        **self._rerun_resource_kwargs(),
+                        make_archive=True,
+                        use_spin=use_spin,
+                    )
             return False
 
         # in the case that the calculation finishes but results in a spin value lower

--- a/vasp_manager/calculation_manager/rlx_coarse.py
+++ b/vasp_manager/calculation_manager/rlx_coarse.py
@@ -153,8 +153,14 @@ class RlxCoarseCalculationManager(BaseCalculationManager):
             self.logger.debug(tail_output)
             if self.to_rerun:
                 self.logger.info(f"Rerunning {self.calc_dir}")
-                # increase nodes as its likely the calculation failed
-                self.setup_calc(increase_walltime_by_factor=2, make_archive=True)
+                nsw = self.vasp_input_creator.calc_config.nsw
+                completed_steps = len(pgrep(stdout_path, "F="))
+                if completed_steps >= nsw:
+                    # ran all NSW steps without converging — relaunch same params
+                    self.setup_calc(make_archive=True)
+                else:
+                    # timed out before completing NSW — apply rerun strategy
+                    self.setup_calc(**self._rerun_resource_kwargs(), make_archive=True)
             return False
 
         self.logger.info(f"{self.mode.upper()} Calculation: reached required accuracy")

--- a/vasp_manager/calculation_manager/static.py
+++ b/vasp_manager/calculation_manager/static.py
@@ -155,8 +155,7 @@ class StaticCalculationManager(BaseCalculationManager):
             if self.to_rerun:
                 self.logger.info(f"Rerunning {self.calc_dir}")
                 self._from_scratch()
-                # increase nodes as its likely the calculation failed
-                self.setup_calc(increase_walltime_by_factor=2)
+                self.setup_calc(**self._rerun_resource_kwargs())
             return False
 
         self._results = {}

--- a/vasp_manager/config.py
+++ b/vasp_manager/config.py
@@ -1,6 +1,7 @@
 import json
 from functools import lru_cache
 from pathlib import Path
+from typing import Literal
 
 from pydantic import BaseModel, ConfigDict
 
@@ -17,6 +18,11 @@ class ComputingConfig(BaseModel):
     vasp_module: str
     ncore: int
     ncore_per_node: int
+
+    # Job resource tuning (optional, backward-compatible defaults)
+    atoms_per_node: int = 32
+    rerun_increase: Literal["nodes", "walltime"] = "walltime"
+    rerun_increase_factor: int = 2
 
 
 class CalcConfig(BaseModel):

--- a/vasp_manager/tests/test_calculation_managers.py
+++ b/vasp_manager/tests/test_calculation_managers.py
@@ -397,7 +397,7 @@ def test_static_rerun(calcs_dir):
 
 def test_bulkmod_rerun(calcs_dir):
     """
-    Assert bulkmod reruns from scratch if failed
+    Assert bulkmod reruns only the failed strain, not all strains
     """
     material_dir = calcs_dir / "material_needs_rerun"
     bulkmod_dir = material_dir / "bulkmod"
@@ -410,15 +410,12 @@ def test_bulkmod_rerun(calcs_dir):
     assert not bulkmod_manager.is_done
     assert bulkmod_manager.results is None
 
-    bulkmod_dir_contents = list(bulkmod_dir.glob("*"))
-    strain_dirs = [d for d in bulkmod_dir_contents if d.is_dir()]
-    # Each strain is an independent static calculation with its own full input set
-    assert len(strain_dirs) == len(bulkmod_manager.strains)
-    for strain_dir in strain_dirs:
-        strain_dir_files = list(strain_dir.glob("*"))
-        strain_file_names = [f.name for f in strain_dir_files if f.is_file()]
-        for f_name in INPUT_FILES:
-            assert f_name in strain_file_names
+    # The failed strain (strain_-1) should have been cleaned and recreated
+    failed_strain_dir = bulkmod_dir / "strain_-1"
+    assert failed_strain_dir.exists()
+    failed_files = [f.name for f in failed_strain_dir.glob("*") if f.is_file()]
+    for f_name in INPUT_FILES:
+        assert f_name in failed_files
 
 
 def test_elastic_rerun(calcs_dir):

--- a/vasp_manager/tests/test_config.py
+++ b/vasp_manager/tests/test_config.py
@@ -231,3 +231,73 @@ def test_calc_config_custom_override_applied(config_dir):
     base = configs["rlx-coarse"]
     merged = CalcConfig.model_validate({**base.model_dump(), "kspacing": 0.99})
     assert merged.kspacing == 0.99
+
+
+# ---------------------------------------------------------------------------
+# ComputingConfig job resource fields
+# ---------------------------------------------------------------------------
+
+
+def test_computing_config_defaults_when_fields_omitted(tmp_path):
+    """
+    atoms_per_node, rerun_increase, and rerun_increase_factor use sensible
+    defaults when not present in the JSON
+    """
+    config_dir = _make_computing_config_json(tmp_path)
+    cc = load_computing_config(config_dir)
+    assert cc.atoms_per_node == 32
+    assert cc.rerun_increase == "walltime"
+    assert cc.rerun_increase_factor == 2
+
+
+def test_computing_config_custom_job_resource_fields(tmp_path):
+    """
+    Custom atoms_per_node, rerun_increase, and rerun_increase_factor are
+    loaded from JSON
+    """
+    config = {
+        "computer": "quest",
+        "quest": {
+            "user_id": "testuser",
+            "potcar_dir": "/fake/potcars",
+            "queuetype": "short",
+            "allocation": "fake_alloc",
+            "constraint": "cpu",
+            "vasp_module": "vasp/6.0",
+            "ncore": 16,
+            "ncore_per_node": 64,
+            "atoms_per_node": 16,
+            "rerun_increase": "nodes",
+            "rerun_increase_factor": 3,
+        },
+    }
+    (tmp_path / "computing_config.json").write_text(json.dumps(config))
+    cc = load_computing_config(tmp_path)
+    assert cc.atoms_per_node == 16
+    assert cc.rerun_increase == "nodes"
+    assert cc.rerun_increase_factor == 3
+
+
+def test_computing_config_invalid_rerun_increase_raises(tmp_path):
+    """
+    An invalid rerun_increase value raises a ValidationError
+    """
+    from pydantic import ValidationError
+
+    config = {
+        "computer": "personal",
+        "personal": {
+            "user_id": "testuser",
+            "potcar_dir": "/fake/potcars",
+            "queuetype": "regular",
+            "allocation": "fake_alloc",
+            "constraint": "cpu",
+            "vasp_module": "vasp/6.0",
+            "ncore": 16,
+            "ncore_per_node": 128,
+            "rerun_increase": "memory",
+        },
+    }
+    (tmp_path / "computing_config.json").write_text(json.dumps(config))
+    with pytest.raises(ValidationError):
+        load_computing_config(tmp_path)

--- a/vasp_manager/vasp_input_creator.py
+++ b/vasp_manager/vasp_input_creator.py
@@ -167,9 +167,6 @@ class VaspInputCreator:
     def n_nodes(self) -> int:
         atoms_per_node = self.computing_config.atoms_per_node
         num_nodes = (len(self.structure) // atoms_per_node) + 1
-        if self.computer == "quest":
-            # quest has ~2x smaller nodes than perlmutter
-            num_nodes *= 2
         num_nodes *= self.increase_nodes_by_factor
         return num_nodes
 

--- a/vasp_manager/vasp_input_creator.py
+++ b/vasp_manager/vasp_input_creator.py
@@ -165,8 +165,8 @@ class VaspInputCreator:
 
     @cached_property
     def n_nodes(self) -> int:
-        # start with 1 node per 32 atoms
-        num_nodes = (len(self.structure) // 32) + 1
+        atoms_per_node = self.computing_config.atoms_per_node
+        num_nodes = (len(self.structure) // atoms_per_node) + 1
         if self.computer == "quest":
             # quest has ~2x smaller nodes than perlmutter
             num_nodes *= 2


### PR DESCRIPTION
- Add configurable job resource parameters (`atoms_per_node`, `rerun_increase`, `rerun_increase_factor`) to `ComputingConfig` for fine-grained control over rerun scaling
- Add smart rerun diagnosis: relaxations now distinguish "completed all NSW without converging" (relaunch same params) from "timed out" (apply rerun strategy with resource scaling)
- Refactor bulkmod to handle per-strain failures individually instead of failing the entire calculation
- Remove extra Quest node logic and simplify node/task computation in `VaspInputCreator`