### PR TITLE
Update docstrings to Google-style standard

### DIFF
--- a/docs/user/setting_up.md
+++ b/docs/user/setting_up.md
@@ -118,7 +118,7 @@ For each desired calculation mode, set the INCAR tags in this json.
 * `nsw` (`int`)
 * `ibrion` (`int`)
 * `isif` (`int`)
-* `lreal` (`bool`): [".FALSE.", ".TRUE."]
+* `lreal` (`bool`)
 * `potim` (`float`)
 * `ediffg` (`float`)
 * `iopt` (`int`)
@@ -130,9 +130,9 @@ For each desired calculation mode, set the INCAR tags in this json.
 * `sigma` (`float`)
 * `amix` (`float`)
 * `bmix` (`float`)
-* `lwave` (`bool`): [".FALSE.", ".TRUE."]
-* `lcharge` (`bool`): [".FALSE.", ".TRUE."]
-* `lvot` (`bool`): [".FALSE.", ".TRUE."]
+* `lwave` (`bool`)
+* `lcharge` (`bool`)
+* `lvot` (`bool`)
 * `kpar` (`int`)
 * `gga` (`str`)
 * `walltime` (`str`)
@@ -141,9 +141,7 @@ For each desired calculation mode, set the INCAR tags in this json.
 
     * In `json` files, the equivalent of python's `None` is `null`.
     * `VASP` (Fortran) expects `bool` data to be passed as `".FALSE."` or
-      `".TRUE."`.
-    * I prefer to write small floats (e.g. `"1e-03"`) as a string to prevent
-      them from being parsed as decimals (e.g. `0.001`).
+      `".TRUE."`; this is automatically converted for you.
     * `walltime` should be passed as `"hh:mm:ss"`. You should try to set this
       such that your job hits NSW before it runs out of time.  If your job
       times out, an archive will be made and the calculation will be

--- a/vasp_manager/__init__.py
+++ b/vasp_manager/__init__.py
@@ -1,5 +1,4 @@
-"""
-vasp_manager
+"""vasp_manager
 
 A python package to run and analyze VASP calculations
 """

--- a/vasp_manager/analyzer/bulkmod_analyzer.py
+++ b/vasp_manager/analyzer/bulkmod_analyzer.py
@@ -19,15 +19,18 @@ logger = logging.getLogger(__name__)
 
 
 class BulkmodAnalyzer:
+    """Fits a Birch-Murnaghan EOS to a completed bulkmod calculation to extract the
+    bulk modulus.
+    """
+
     def __init__(
         self,
         calc_dir: WorkingDirectory,
         rounding_precision: int = 3,
     ) -> None:
-        """
-        Args:
-            calc_dir: path to bulkmod calculation directory
-            rounding_precision: precision to round calculated quantities
+        """Args:
+        calc_dir: path to bulkmod calculation directory
+        rounding_precision: precision to round calculated quantities
         """
         self.calc_dir = Path(calc_dir)
         self.rounding_precision = rounding_precision
@@ -58,8 +61,19 @@ class BulkmodAnalyzer:
 
     @staticmethod
     def analyze_bulkmod(calc_dir: Path, rounding_precision: int) -> dict:
-        """
-        Fit an EOS to calculate the bulk modulus from a finished bulkmod calculation
+        """Fit a Birch-Murnaghan EOS to extract the bulk modulus from a finished
+        bulkmod calculation.
+
+        Args:
+            calc_dir: path to the bulkmod calculation directory containing strain_*
+                subdirectories, each with a POSCAR and vasprun.xml
+            rounding_precision: decimal places to round the bulk modulus
+
+        Returns:
+            dict with key "B" mapping to the bulk modulus in GPa
+
+        Raises:
+            Exception: if a strain directory has no vasprun.xml
         """
         strain_dirs = [path for path in calc_dir.glob("strain*") if path.is_dir()]
         strain_dirs = sorted(strain_dirs, key=lambda d: int(d.name.split("_")[-1]))
@@ -93,6 +107,7 @@ class BulkmodAnalyzer:
 
     @property
     def results(self) -> dict:
+        """Bulk modulus results dict (computed lazily on first access)."""
         if getattr(self, "_results", None) is None:
             self._results = self.analyze_bulkmod(self.calc_dir, self.rounding_precision)
         return self._results

--- a/vasp_manager/analyzer/elastic_analyzer.py
+++ b/vasp_manager/analyzer/elastic_analyzer.py
@@ -18,14 +18,17 @@ if TYPE_CHECKING:
 
 
 class ElasticAnalyzer:
+    """Computes elastic and acoustic properties (B, G, sound velocities) from a
+    6x6 stiffness tensor in Voigt notation using Voigt, Reuss, and VRH averaging.
+    """
+
     def __init__(
         self,
         cij: NDArray,
         structure: Structure,
         rounding_precision: int = 3,
     ) -> None:
-        """
-        Args:
+        """Args:
             cij: stiffness tensor in Voigt notation in units of GPa
             structure: the associated pymatgen structure
             rounding_precision: precision to round calculated quantities
@@ -72,6 +75,7 @@ class ElasticAnalyzer:
 
     @property
     def density(self) -> float:
+        """Density of the structure in g/cm^3."""
         return self.structure.density
 
     @property
@@ -89,8 +93,7 @@ class ElasticAnalyzer:
 
     @staticmethod
     def change_elastic_constants_from_vasp(vasp_elastic_tensor: NDArray) -> NDArray:
-        """
-        Args:
+        """Args:
             vasp_elastic_tensor: elastic tensor from VASP OUTCAR
 
         Returns:
@@ -127,8 +130,7 @@ class ElasticAnalyzer:
 
     @staticmethod
     def get_compliance_tensor(cij: NDArray) -> NDArray:
-        """
-        Args:
+        """Args:
             cij: stiffness tensor
 
         Returns:
@@ -139,8 +141,7 @@ class ElasticAnalyzer:
 
     @staticmethod
     def get_VRH_average(mod1: Floating, mod2: Floating) -> Floating:
-        """
-        Args:
+        """Args:
             mod1: B or G Voigt
             mod2: B or G Reuss
 
@@ -151,8 +152,7 @@ class ElasticAnalyzer:
 
     @staticmethod
     def get_B_Reuss(sij: NDArray) -> float:
-        """
-        Args:
+        """Args:
             sij: compliance tensor
 
         Returns:
@@ -165,8 +165,7 @@ class ElasticAnalyzer:
 
     @staticmethod
     def get_B_Voigt(cij: NDArray) -> float:
-        """
-        Args:
+        """Args:
             cij: stiffness tensor
 
         Returns:
@@ -179,8 +178,7 @@ class ElasticAnalyzer:
 
     @staticmethod
     def get_G_Reuss(sij: NDArray) -> float:
-        """
-        Args:
+        """Args:
             sij: compliance tensor
 
         Returns:
@@ -195,8 +193,7 @@ class ElasticAnalyzer:
 
     @staticmethod
     def get_G_Voigt(cij: NDArray) -> float:
-        """
-        Args:
+        """Args:
             cij: stiffness tensor
 
         Returns:
@@ -215,9 +212,13 @@ class ElasticAnalyzer:
         shearmod: Floating,
         density: Floating,
     ) -> Floating:
-        """
+        """Args:
+            bulkmod: bulk modulus in GPa
+            shearmod: shear modulus in GPa
+            density: density in g/cm^3
+
         Returns:
-            vl: longitudinal speed of sound
+            vl: longitudinal speed of sound in km/s
         """
         vl = np.sqrt((bulkmod + 4 / 3 * shearmod) / density)
         return vl
@@ -227,9 +228,12 @@ class ElasticAnalyzer:
         shearmod: Floating,
         density: Floating,
     ) -> Floating:
-        """
+        """Args:
+            shearmod: shear modulus in GPa
+            density: density in g/cm^3
+
         Returns:
-            vl: transverse speed of sound
+            vt: transverse speed of sound in km/s
         """
         vt = np.sqrt(shearmod / density)
         return vt
@@ -240,9 +244,13 @@ class ElasticAnalyzer:
         shearmod: Floating,
         density: Floating,
     ) -> Floating:
-        """
+        """Args:
+            bulkmod: bulk modulus in GPa
+            shearmod: shear modulus in GPa
+            density: density in g/cm^3
+
         Returns:
-            vs: speed of sound
+            vs: average (Debye) speed of sound in km/s
         """
         vl = np.sqrt((bulkmod + 4 / 3 * shearmod) / density)
         vt = np.sqrt(shearmod / density)
@@ -251,9 +259,8 @@ class ElasticAnalyzer:
 
     @staticmethod
     def check_elastically_unstable(cij: NDArray) -> bool:
-        """
-        Returns:
-            True if compound is elastically unstable
+        """Returns:
+        True if compound is elastically unstable
         """
         eigenvalues, eigenvectors = np.linalg.eig(cij)
         born_critera_satisfied = np.all(eigenvalues > 0)
@@ -314,15 +321,15 @@ class ElasticAnalyzer:
         )
 
     def _analyze_elastic(self, properties: list | None = None) -> dict:
-        """
-        Grabs important quantities from the elastic calculation results
+        """Collect elastic and acoustic properties into a results dict.
 
         Args:
-            properties (list): names of properties to calculate
+            properties: names of properties to include. If None, all available
+                properties are included (B_Reuss, B_Voigt, B_VRH, G_Reuss,
+                G_Voigt, G_VRH, unstable, elastic_tensor, vl, vt, vs)
 
         Returns:
-            elastic_dict (dict): dict of extracted info from
-                elastic constants
+            dict mapping property names to their computed values
         """
         properties_map = {
             "B_Reuss": "b_reuss",
@@ -347,6 +354,7 @@ class ElasticAnalyzer:
 
     @property
     def results(self) -> dict:
+        """Elastic results dict (computed lazily on first access)."""
         if getattr(self, "_results", None) is None:
             self._results = self._analyze_elastic()
         return self._results
@@ -357,15 +365,23 @@ class ElasticAnalyzer:
         calc_dir: WorkingDirectory,
         **kwargs,
     ) -> ElasticAnalyzer:
-        """
-        Method to construct ElasticAnalyzer from a calculation directory.
-        The directory should contain a POSCAR and an OUTCAR with elastic constants
+        """Construct an ElasticAnalyzer from a calculation directory.
+
+        The directory must contain a POSCAR and an OUTCAR with a full elastic tensor.
+        Elastic constants are scraped from the OUTCAR and cached to
+        elastic_constants.txt on the first call.
 
         Args:
-            calc_dir:
+            calc_dir: path to the elastic calculation directory
+            **kwargs: additional keyword arguments forwarded to ElasticAnalyzer.__init__
 
         Returns:
-            Instance of ElasticAnalyzer
+            ElasticAnalyzer instance constructed from the directory
+
+        Raises:
+            ValueError: if calc_dir does not exist
+            FileNotFoundError: if no OUTCAR is found in calc_dir
+            RuntimeError: if the elastic tensor cannot be parsed from the OUTCAR
         """
         calc_dir = Path(calc_dir)
         if not calc_dir.exists():

--- a/vasp_manager/calculation_manager/base.py
+++ b/vasp_manager/calculation_manager/base.py
@@ -23,9 +23,7 @@ if TYPE_CHECKING:
 
 
 class BaseCalculationManager(ABC):
-    """
-    Runs vasp job workflow for a single material
-    """
+    """Runs vasp job workflow for a single material"""
 
     def __init__(
         self,
@@ -36,18 +34,17 @@ class BaseCalculationManager(ABC):
         ignore_personal_errors: bool = True,
         from_scratch: bool = False,  # DANGEROUS, WILL DELETE PREVIOUS CALCULATION
     ):
-        """
-        Args:
-            material_dir: path to a directory for a single material
-                ex. calculations/AlAs
-            to_rerun: if True, rerun failed calculations
-            to_submit: if True, submit calculations to job manager
-            primitive: if True, find primitive cell, else find conventional cell
-            ignore_personal_errors: if True, ignore job submission errors
-                if on personal computer
-            from_scratch: if True, remove the calculation's directory and
-                restart
-                note: DANGEROUS
+        """Args:
+        material_dir: path to a directory for a single material
+            ex. calculations/AlAs
+        to_rerun: if True, rerun failed calculations
+        to_submit: if True, submit calculations to job manager
+        primitive: if True, find primitive cell, else find conventional cell
+        ignore_personal_errors: if True, ignore job submission errors
+            if on personal computer
+        from_scratch: if True, remove the calculation's directory and
+            restart
+            note: DANGEROUS
         """
         self.material_dir = Path(material_dir)
         self.to_rerun = to_rerun
@@ -111,8 +108,7 @@ class BaseCalculationManager(ABC):
         return {"increase_walltime_by_factor": cc.rerun_increase_factor}
 
     def _load_structure(self, poscar_path: Path | None = None) -> Structure:
-        """
-        Load a pymatgen Structure from a POSCAR file.
+        """Load a pymatgen Structure from a POSCAR file.
 
         Args:
             poscar_path: path to POSCAR/CONTCAR. Defaults to
@@ -133,8 +129,7 @@ class BaseCalculationManager(ABC):
         return structure
 
     def _load_structure_for_rerun(self) -> Structure:
-        """
-        Load structure for a rerun, checking for archives first.
+        """Load structure for a rerun, checking for archives first.
 
         If archives exist in calc_dir, loads the CONTCAR from the latest
         archive. Otherwise falls back to poscar_source_path.
@@ -198,30 +193,40 @@ class BaseCalculationManager(ABC):
 
     @property
     def job_exists(self) -> bool:
+        """True if all runs have a jobid file."""
         if not self.vasp_runs:
             return False
         return all(r.job_manager.job_exists for r in self.vasp_runs.values())
 
     @property
     def job_complete(self) -> bool:
+        """True if all runs have finished (no longer in the SLURM queue)."""
         if not self.vasp_runs:
             return False
         return all(r.job_manager.job_complete for r in self.vasp_runs.values())
 
     def submit_job(self) -> bool:
+        """Submit all runs to the job manager.
+
+        Returns:
+            True if all jobs were submitted successfully
+        """
         if not self.vasp_runs:
             return False
         return all(r.job_manager.submit_job() for r in self.vasp_runs.values())
 
     @property
     def stopped(self) -> bool:
+        """True if a STOP file exists in the material directory."""
         return (self.material_dir / "STOP").exists()
 
     def stop(self) -> None:
+        """Create a STOP file to prevent further calculation attempts."""
         with open(self.material_dir / "STOP", "w+"):
             pass
 
     def _cancel_previous_job(self) -> None:
+        """Cancel the SLURM job for this calculation and remove its jobid file."""
         jobid_path = self.calc_dir / "jobid"
         if jobid_path.exists():
             with open(jobid_path) as fr:
@@ -231,5 +236,6 @@ class BaseCalculationManager(ABC):
             os.remove(jobid_path)
 
     def _from_scratch(self) -> None:
+        """Cancel the existing job and delete the calculation directory."""
         self._cancel_previous_job()
         shutil.rmtree(self.calc_dir)

--- a/vasp_manager/calculation_manager/bulkmod.py
+++ b/vasp_manager/calculation_manager/bulkmod.py
@@ -27,8 +27,7 @@ logger = logging.getLogger(__name__)
 
 
 class BulkmodCalculationManager(BaseCalculationManager):
-    """
-    Runs bulk modulus job workflow for a single material.
+    """Runs bulk modulus job workflow for a single material.
 
     Each strain is an independent static calculation with its own
     VaspInputCreator, JobManager, and SLURM job.
@@ -46,21 +45,20 @@ class BulkmodCalculationManager(BaseCalculationManager):
         tail: int = 5,
         strains: None | NDArray = None,
     ):
-        """
-        Args:
-            material_dir: path to a directory for a single material
-            to_rerun: if True, rerun failed calculations
-            to_submit: if True, submit calculations to job manager
-            primitive: if True, find primitive cell, else find conventional cell
-            ignore_personal_errors: if True, ignore job submission errors
-                if on personal computer
-            from_scratch: if True, remove the calculation's directory and
-                restart
-            from_relax: if True, use CONTCAR from relax
-            tail: number of last lines to log in debugging if job failed
-            strains: fractional strain along each axis for each deformation
-                if None, use np.linspace(start=0.925, stop=1.075, number=11)**(1/3)
-                len(strains) must be odd and strains must be centered around 0
+        """Args:
+        material_dir: path to a directory for a single material
+        to_rerun: if True, rerun failed calculations
+        to_submit: if True, submit calculations to job manager
+        primitive: if True, find primitive cell, else find conventional cell
+        ignore_personal_errors: if True, ignore job submission errors
+            if on personal computer
+        from_scratch: if True, remove the calculation's directory and
+            restart
+        from_relax: if True, use CONTCAR from relax
+        tail: number of last lines to log in debugging if job failed
+        strains: fractional strain along each axis for each deformation
+            if None, use np.linspace(start=0.925, stop=1.075, number=11)**(1/3)
+            len(strains) must be odd and strains must be centered around 0
         """
         self.from_relax = from_relax
         self.strains = (
@@ -156,6 +154,14 @@ class BulkmodCalculationManager(BaseCalculationManager):
         return runs
 
     def _check_use_spin(self) -> bool:
+        """Determine whether spin polarization should be used for strain calculations.
+
+        If from_relax is True, checks the relaxation stdout for magnetic moments.
+        Otherwise, defaults to True.
+
+        Returns:
+            True if spin polarization should be enabled
+        """
         if self.from_relax:
             rlx_stdout = self.material_dir / "rlx" / "stdout.txt"
             rlx_mags = pgrep(rlx_stdout, "mag=", stop_after_first_match=True)
@@ -170,7 +176,16 @@ class BulkmodCalculationManager(BaseCalculationManager):
         increase_nodes_by_factor: int = 1,
         increase_walltime_by_factor: int = 1,
     ) -> VaspRun:
-        """Create input files for a single strain and return its VaspRun."""
+        """Create input files for a single strain and return its VaspRun.
+
+        Args:
+            strain_index: index into self.strains and self.strain_names
+            increase_nodes_by_factor: multiply the node count by this factor
+            increase_walltime_by_factor: multiply the walltime by this factor
+
+        Returns:
+            VaspRun for the newly created strain directory
+        """
         strain = self.strains[strain_index]
         strain_name = self.strain_names[strain_index]
         strain_dir = self.calc_dir / strain_name
@@ -227,8 +242,14 @@ class BulkmodCalculationManager(BaseCalculationManager):
         increase_nodes_by_factor: int = 1,
         increase_walltime_by_factor: int = 1,
     ) -> None:
-        """
-        Sets up an EOS bulkmod calculation with independent strain jobs.
+        """Set up and optionally submit an EOS bulkmod calculation with independent
+        strain jobs.
+
+        Args:
+            increase_nodes_by_factor: multiply the node count by this factor for all
+                strain jobs
+            increase_walltime_by_factor: multiply the walltime by this factor for all
+                strain jobs
         """
         if not self.from_relax:
             msg = (
@@ -258,8 +279,7 @@ class BulkmodCalculationManager(BaseCalculationManager):
                 self.setup_calc()
 
     def check_calc(self) -> bool:
-        """
-        Checks result of bulk modulus calculation
+        """Checks result of bulk modulus calculation
 
         Returns:
             bulkmod_sucessful: if True, bulkmod calculation completed successfully
@@ -315,12 +335,17 @@ class BulkmodCalculationManager(BaseCalculationManager):
 
     @property
     def is_done(self) -> bool:
+        """True if all strain calculations completed successfully (computed lazily)."""
         if getattr(self, "_is_done", None) is None:
             self._is_done = self.check_calc()
         return self._is_done
 
     @property
     def results(self) -> None | str | dict:
+        """Bulk modulus results dict, or None/"STOPPED" if not finished.
+
+        Runs BulkmodAnalyzer on first access after is_done is True.
+        """
         if not self.is_done:
             if self.stopped:
                 return "STOPPED"
@@ -349,6 +374,7 @@ class BulkmodCalculationManager(BaseCalculationManager):
                 os.remove(jobid_path)
 
     def _from_scratch(self) -> None:
+        """Cancel all strain jobs, delete the calculation directory, and reset runs."""
         self._cancel_previous_job()
         shutil.rmtree(self.calc_dir)
         self._vasp_runs = None

--- a/vasp_manager/calculation_manager/elastic.py
+++ b/vasp_manager/calculation_manager/elastic.py
@@ -20,9 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 class ElasticCalculationManager(BaseCalculationManager):
-    """
-    Runs elastic deformation job workflow for a single material
-    """
+    """Runs elastic deformation job workflow for a single material"""
 
     def __init__(
         self,
@@ -34,8 +32,7 @@ class ElasticCalculationManager(BaseCalculationManager):
         from_scratch: bool = False,
         tail: int = 5,
     ):
-        """
-        Args:
+        """Args:
             material_dir: path to a directory for a single material
             to_rerun: if True, rerun failed calculations
             to_submit: if True, submit calculations to job manager
@@ -76,6 +73,13 @@ class ElasticCalculationManager(BaseCalculationManager):
         return self.material_dir / "rlx" / "CONTCAR"
 
     def _check_use_spin(self) -> bool:
+        """Determine whether spin polarization should be used for the elastic calculation.
+
+        Checks the relaxation stdout for magnetic moments.
+
+        Returns:
+            True if the relaxation produced non-zero magnetic moments
+        """
         rlx_stdout = self.material_dir / "rlx" / "stdout.txt"
         rlx_mags = pgrep(rlx_stdout, "mag=", stop_after_first_match=True)
         use_spin = len(rlx_mags) != 0
@@ -86,11 +90,14 @@ class ElasticCalculationManager(BaseCalculationManager):
         increase_nodes_by_factor: int = 1,
         increase_walltime_by_factor: int = 1,
     ) -> None:
-        """
-        Runs elastic constants routine through VASP
+        """Set up and optionally submit an elastic constants calculation.
 
-        By default, requires relaxation (as the elastic constants routine needs
-            the cell to be nearly at equilibrium)
+        Requires a previous relaxation, as the elastic constants routine needs the
+        cell to be nearly at equilibrium.
+
+        Args:
+            increase_nodes_by_factor: multiply the node count by this factor
+            increase_walltime_by_factor: multiply the walltime by this factor
         """
         self.vasp_input_creator.increase_nodes_by_factor = increase_nodes_by_factor
         self.vasp_input_creator.increase_walltime_by_factor = increase_walltime_by_factor
@@ -104,8 +111,7 @@ class ElasticCalculationManager(BaseCalculationManager):
                 self.setup_calc()
 
     def check_calc(self) -> bool:
-        """
-        Checks result of elastic calculation
+        """Checks result of elastic calculation
 
         Returns:
             elastic_successful: if True, elastic calculation completed
@@ -172,12 +178,14 @@ class ElasticCalculationManager(BaseCalculationManager):
 
     @property
     def is_done(self) -> bool:
+        """True if all elastic deformations completed successfully (computed lazily)."""
         if getattr(self, "_is_done", None) is None:
             self._is_done = self.check_calc()
         return self._is_done
 
     @property
     def results(self) -> None | str | dict:
+        """Elastic results dict from ElasticAnalyzer, or None/"STOPPED" if not done."""
         if not self.is_done:
             if self.stopped:
                 return "STOPPED"
@@ -191,8 +199,10 @@ class ElasticCalculationManager(BaseCalculationManager):
         return self._results
 
     def _analyze_elastic(self) -> dict:
-        """
-        Gets results from elastic calculation
+        """Run ElasticAnalyzer on the completed calculation directory.
+
+        Returns:
+            dict of elastic and acoustic properties from ElasticAnalyzer.results
         """
         ea = ElasticAnalyzer.from_calc_dir(self.calc_dir)
         if ea.results.get("elastically_unstable"):

--- a/vasp_manager/calculation_manager/rlx.py
+++ b/vasp_manager/calculation_manager/rlx.py
@@ -20,9 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 class RlxCalculationManager(BaseCalculationManager):
-    """
-    Runs relaxation job workflow for a single material
-    """
+    """Runs relaxation job workflow for a single material"""
 
     def __init__(
         self,
@@ -37,23 +35,22 @@ class RlxCalculationManager(BaseCalculationManager):
         max_reruns: int = 3,
         magmom_per_atom_cutoff: float = 0.0,
     ):
-        """
-        Args:
-            material_dir: path to a directory for a single material
-            to_rerun: if True, rerun failed calculations
-            to_submit: if True, submit calculations to job manager
-            primitive: if True, find primitive cell, else find conventional cell
-            ignore_personal_errors: if True, ignore job submission errors
-                if on personal computer
-            from_scratch: if True, remove the calculation's directory and
-                restart
-            from_coarse_relax: if True, use CONTCAR from coarse relax
-            tail: number of last lines to log in debugging if job failed
-            max_reruns: maximum number of times to rerun rlx before refusing to
-                continue
-            magmom_per_atom_cutoff: calculations that result in
-                magmom_per_atom less than this parameter will be automatically
-                rerun without spin-polarization
+        """Args:
+        material_dir: path to a directory for a single material
+        to_rerun: if True, rerun failed calculations
+        to_submit: if True, submit calculations to job manager
+        primitive: if True, find primitive cell, else find conventional cell
+        ignore_personal_errors: if True, ignore job submission errors
+            if on personal computer
+        from_scratch: if True, remove the calculation's directory and
+            restart
+        from_coarse_relax: if True, use CONTCAR from coarse relax
+        tail: number of last lines to log in debugging if job failed
+        max_reruns: maximum number of times to rerun rlx before refusing to
+            continue
+        magmom_per_atom_cutoff: calculations that result in
+            magmom_per_atom less than this parameter will be automatically
+            rerun without spin-polarization
         """
         self.from_coarse_relax = from_coarse_relax
         self.tail = tail
@@ -94,8 +91,13 @@ class RlxCalculationManager(BaseCalculationManager):
         make_archive: bool = False,
         use_spin: bool = True,
     ) -> None:
-        """
-        Sets up a fine relaxation
+        """Set up and optionally submit a fine relaxation.
+
+        Args:
+            increase_nodes_by_factor: multiply the node count by this factor
+            increase_walltime_by_factor: multiply the walltime by this factor
+            make_archive: if True, archive the current run before writing new input files
+            use_spin: if False, suppress spin polarization in the INCAR
         """
         if make_archive:
             self.vasp_input_creator.make_archive()
@@ -112,8 +114,7 @@ class RlxCalculationManager(BaseCalculationManager):
                 self.setup_calc()
 
     def check_calc(self) -> bool:
-        """
-        Checks if calculation has finished and reached required accuracy
+        """Checks if calculation has finished and reached required accuracy
 
         Returns:
             relaxation_successful: if True, relaxation completed successfully
@@ -178,10 +179,10 @@ class RlxCalculationManager(BaseCalculationManager):
                 nsw = self.vasp_input_creator.calc_config.nsw
                 completed_steps = len(pgrep(stdout_path, "F="))
                 if completed_steps >= nsw:
-                    # ran all NSW steps without converging — relaunch same params
+                    # ran all NSW steps without converging -- relaunch same params
                     self.setup_calc(make_archive=True, use_spin=use_spin)
                 else:
-                    # timed out before completing NSW — apply rerun strategy
+                    # timed out before completing NSW -- apply rerun strategy
                     self.setup_calc(
                         **self._rerun_resource_kwargs(),
                         make_archive=True,
@@ -202,8 +203,7 @@ class RlxCalculationManager(BaseCalculationManager):
         return True
 
     def check_volume_difference(self) -> bool:
-        """
-        Checks relaxation runs for volume difference
+        """Checks relaxation runs for volume difference
 
         if abs(volume difference) is >= 5%, reruns relaxation
         only checks for mode='rlx' as that's the structure for further calculation
@@ -264,6 +264,7 @@ class RlxCalculationManager(BaseCalculationManager):
 
     @property
     def is_done(self) -> bool:
+        """True if the relaxation converged and volume is within 5% (computed lazily)."""
         if getattr(self, "_is_done", None) is None:
             self._is_done = False
             calc_done = self.check_calc()
@@ -275,6 +276,9 @@ class RlxCalculationManager(BaseCalculationManager):
 
     @property
     def results(self) -> None | str | dict:
+        """Relaxation results dict with spacegroup and volume change, or None/"STOPPED"
+        if not finished.
+        """
         if not self.is_done:
             if self.stopped:
                 return "STOPPED"

--- a/vasp_manager/calculation_manager/rlx_coarse.py
+++ b/vasp_manager/calculation_manager/rlx_coarse.py
@@ -18,9 +18,7 @@ logger = logging.getLogger(__name__)
 
 
 class RlxCoarseCalculationManager(BaseCalculationManager):
-    """
-    Runs coarse relaxation job workflow for a single material
-    """
+    """Runs coarse relaxation job workflow for a single material"""
 
     def __init__(
         self,
@@ -33,19 +31,18 @@ class RlxCoarseCalculationManager(BaseCalculationManager):
         tail: int = 5,
         max_reruns: int = 3,
     ) -> None:
-        """
-        Args:
-            material_dir: path to a directory for a single material
-            to_rerun: if True, rerun failed calculations
-            to_submit: if True, submit calculations to job manager
-            primitive: if True, find primitive cell, else find conventional cell
-            ignore_personal_errors: if True, ignore job submission errors
-                if on personal computer
-            from_scratch: if True, remove the calculation's directory and
-                restart
-            tail: number of last lines to log in debugging if job failed
-            max_reruns: maximum number of times to rerun rlx-coarse before
-                continuing to rlx
+        """Args:
+        material_dir: path to a directory for a single material
+        to_rerun: if True, rerun failed calculations
+        to_submit: if True, submit calculations to job manager
+        primitive: if True, find primitive cell, else find conventional cell
+        ignore_personal_errors: if True, ignore job submission errors
+            if on personal computer
+        from_scratch: if True, remove the calculation's directory and
+            restart
+        tail: number of last lines to log in debugging if job failed
+        max_reruns: maximum number of times to rerun rlx-coarse before
+            continuing to rlx
         """
         self.tail = tail
         self.max_reruns = max_reruns
@@ -79,8 +76,12 @@ class RlxCoarseCalculationManager(BaseCalculationManager):
         increase_walltime_by_factor: int = 1,
         make_archive: bool = False,
     ) -> None:
-        """
-        Sets up a coarse relaxation
+        """Set up and optionally submit a coarse relaxation.
+
+        Args:
+            increase_nodes_by_factor: multiply the node count by this factor
+            increase_walltime_by_factor: multiply the walltime by this factor
+            make_archive: if True, archive the current run before writing new input files
         """
         if make_archive:
             self.vasp_input_creator.make_archive()
@@ -98,8 +99,7 @@ class RlxCoarseCalculationManager(BaseCalculationManager):
                 self.setup_calc()
 
     def check_calc(self) -> bool:
-        """
-        Checks if calculation has finished and reached required accuracy
+        """Checks if calculation has finished and reached required accuracy
 
         Returns:
             relaxation_successful (bool): if True, relaxation completed successfully
@@ -156,10 +156,10 @@ class RlxCoarseCalculationManager(BaseCalculationManager):
                 nsw = self.vasp_input_creator.calc_config.nsw
                 completed_steps = len(pgrep(stdout_path, "F="))
                 if completed_steps >= nsw:
-                    # ran all NSW steps without converging — relaunch same params
+                    # ran all NSW steps without converging -- relaunch same params
                     self.setup_calc(make_archive=True)
                 else:
-                    # timed out before completing NSW — apply rerun strategy
+                    # timed out before completing NSW -- apply rerun strategy
                     self.setup_calc(**self._rerun_resource_kwargs(), make_archive=True)
             return False
 
@@ -169,12 +169,14 @@ class RlxCoarseCalculationManager(BaseCalculationManager):
 
     @property
     def is_done(self) -> bool:
+        """True if the coarse relaxation reached required accuracy (computed lazily)."""
         if getattr(self, "_is_done", None) is None:
             self._is_done = self.check_calc()
         return self._is_done
 
     @property
     def results(self) -> str:
+        """Status string: "done", "not finished", or "STOPPED"."""
         if not self.is_done:
             if self.stopped:
                 self._results = "STOPPED"

--- a/vasp_manager/calculation_manager/static.py
+++ b/vasp_manager/calculation_manager/static.py
@@ -20,9 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 class StaticCalculationManager(BaseCalculationManager):
-    """
-    Runs static job workflow for a single material
-    """
+    """Runs static job workflow for a single material"""
 
     def __init__(
         self,
@@ -35,18 +33,17 @@ class StaticCalculationManager(BaseCalculationManager):
         from_relax: bool = True,
         tail: int = 5,
     ) -> None:
-        """
-        Args:
-            material_dir: path to a directory for a single material
-            to_rerun: if True, rerun failed calculations
-            to_submit: if True, submit calculations to job manager
-            primitive: if True, find primitive cell, else find conventional cell
-            ignore_personal_errors: if True, ignore job submission errors
-                if on personal computer
-            from_scratch: if True, remove the calculation's directory and
-                restart
-            from_relax: if True, use CONTCAR from relax
-            tail: number of last lines to log in debugging if job failed
+        """Args:
+        material_dir: path to a directory for a single material
+        to_rerun: if True, rerun failed calculations
+        to_submit: if True, submit calculations to job manager
+        primitive: if True, find primitive cell, else find conventional cell
+        ignore_personal_errors: if True, ignore job submission errors
+            if on personal computer
+        from_scratch: if True, remove the calculation's directory and
+            restart
+        from_relax: if True, use CONTCAR from relax
+        tail: number of last lines to log in debugging if job failed
         """
         self.from_relax = from_relax
         self.tail = tail
@@ -79,6 +76,14 @@ class StaticCalculationManager(BaseCalculationManager):
         return poscar_source_path
 
     def _check_use_spin(self) -> bool:
+        """Determine whether spin polarization should be used for the static calculation.
+
+        If from_relax is True, checks the relaxation stdout for magnetic moments.
+        Otherwise, defaults to True.
+
+        Returns:
+            True if spin polarization should be enabled
+        """
         if self.from_relax:
             rlx_stdout = self.material_dir / "rlx" / "stdout.txt"
             rlx_mags = pgrep(rlx_stdout, "mag=", stop_after_first_match=True)
@@ -92,10 +97,13 @@ class StaticCalculationManager(BaseCalculationManager):
         increase_nodes_by_factor: int = 1,
         increase_walltime_by_factor: int = 1,
     ) -> None:
-        """
-        Runs a static SCF calculation through VASP
+        """Set up and optionally submit a static SCF calculation.
 
-        By default, requires previous relaxation run
+        By default, requires a previous relaxation run to source the POSCAR from.
+
+        Args:
+            increase_nodes_by_factor: multiply the node count by this factor
+            increase_walltime_by_factor: multiply the walltime by this factor
         """
         self.vasp_input_creator.increase_nodes_by_factor = increase_nodes_by_factor
         self.vasp_input_creator.increase_walltime_by_factor = increase_walltime_by_factor
@@ -109,10 +117,9 @@ class StaticCalculationManager(BaseCalculationManager):
                 self.setup_calc()
 
     def check_calc(self) -> bool:
-        """
-        Checks result of static calculation
+        """Check result of static calculation.
 
-        Returns
+        Returns:
             static_successful: if True, static calculation completed successfully
         """
         if not self.job_complete:
@@ -171,12 +178,16 @@ class StaticCalculationManager(BaseCalculationManager):
 
     @property
     def is_done(self) -> bool:
+        """True if the static SCF converged successfully (computed lazily)."""
         if getattr(self, "_is_done", None) is None:
             self._is_done = self.check_calc()
         return self._is_done
 
     @property
     def results(self) -> None | str | dict:
+        """Static results dict with final energy and magmom, or None/"STOPPED" if not
+        finished.
+        """
         if not self.is_done:
             if self.stopped:
                 return "STOPPED"

--- a/vasp_manager/config.py
+++ b/vasp_manager/config.py
@@ -59,7 +59,7 @@ class CalcConfig(BaseModel):
     amix: float = 0.4
     bmix: float = 1.0
 
-    # Write flags — Python bools; converted to ".TRUE."/".FALSE." at INCAR write time
+    # Write flags -- Python bools; converted to ".TRUE."/".FALSE." at INCAR write time
     lcharge: bool = False
     lwave: bool = False
     lvtot: bool = False

--- a/vasp_manager/job_manager.py
+++ b/vasp_manager/job_manager.py
@@ -19,9 +19,7 @@ logger = logging.getLogger(__name__)
 
 
 class JobManager:
-    """
-    Handles job submission and status monitoring
-    """
+    """Handles job submission and status monitoring"""
 
     def __init__(
         self,
@@ -32,16 +30,15 @@ class JobManager:
         manager_name: str | None = None,
         ignore_personal_errors: bool = True,
     ) -> None:
-        """
-        Args:
-            calc_dir: base directory of job
-            exe_name: filename for slurm job submission
-            jobid_name: filename for storing slurm jobid
-            config_dir: path to directory containing configuration files. If
-                None, use the parent directory of calc_dir
-            manager_name: name for logging purposes
-            ignore_personal_errors: if True, ignore job submission errors
-                if on personal computer
+        """Args:
+        calc_dir: base directory of job
+        exe_name: filename for slurm job submission
+        jobid_name: filename for storing slurm jobid
+        config_dir: path to directory containing configuration files. If
+            None, use the parent directory of calc_dir
+        manager_name: name for logging purposes
+        ignore_personal_errors: if True, ignore job submission errors
+            if on personal computer
         """
         self.calc_dir = Path(calc_dir)
         self.config_dir = Path(config_dir) if config_dir else self.calc_dir.parents[1]
@@ -71,6 +68,7 @@ class JobManager:
 
     @property
     def job_exists(self) -> bool:
+        """True if a non-empty jobid file exists (also sets self.jobid)."""
         jobid_path = self.calc_dir / self.jobid_name
         if not jobid_path.exists():
             return False
@@ -84,6 +82,11 @@ class JobManager:
 
     @property
     def jobid(self) -> int:
+        """SLURM job ID for this calculation.
+
+        Raises:
+            Exception: if no jobid file exists in calc_dir
+        """
         if not self.job_exists:
             raise Exception(f"jobid has not been set in {self.calc_dir}")
         return self._jobid
@@ -97,8 +100,7 @@ class JobManager:
         self._jobid = jobid_int
 
     def submit_job(self) -> bool:
-        """
-        Submits job, making sure to not make duplicate jobs
+        """Submits job, making sure to not make duplicate jobs
 
         Returns:
             job_submitted_successfully
@@ -139,6 +141,7 @@ class JobManager:
 
     @property
     def job_complete(self) -> bool:
+        """True if the job has finished (no longer in the SLURM queue)."""
         if getattr(self, "_job_complete", None) is None and self.job_exists:
             self._job_complete = self._check_job_complete()
         else:

--- a/vasp_manager/utils.py
+++ b/vasp_manager/utils.py
@@ -72,8 +72,7 @@ def get_pmg_structure_from_poscar(
     international_monoclinic: bool = False,
     return_spacegroup: bool = False,
 ) -> Structure | tuple[Structure, int]:
-    """
-    Args:
+    """Args:
         poscar_path: path to POSCAR file
         to_process: if True, get standard reduced structure
         primitive: if True, get primitive structure, else get
@@ -108,8 +107,7 @@ def get_pmg_structure_from_poscar(
 
 
 def pcat(file_names: Filepath | list[Filepath]) -> str:
-    """
-    Custom python-only replacement for cat
+    """Custom python-only replacement for cat
 
     Args:
         file_names: names of files to cat together
@@ -135,8 +133,7 @@ def pgrep(
     after: int | None = None,
     as_string: bool = False,
 ) -> str | list[str]:
-    """
-    Custom python-only replacement for grep
+    """Custom python-only replacement for grep
 
     Args:
         file_name: path of file
@@ -174,8 +171,7 @@ def phead(
     n_head: int = 1,
     as_string: bool = False,
 ) -> str | list[str]:
-    """
-    Custom python-only replacement for head
+    """Custom python-only replacement for head
 
     Args:
         file_name: path of file
@@ -201,8 +197,7 @@ def ptail(
     n_tail: int = 1,
     as_string: bool = False,
 ) -> str | list[str]:
-    """
-    Custom python-only replacement for grep
+    """Custom python-only replacement for grep
 
     Args:
         file_name: path of file
@@ -226,8 +221,7 @@ def make_potcar_anonymous(
     input_file_name: Filepath,
     output_file_name: Filepath | None = None,
 ) -> None:
-    """
-    Replace full POTCAR with only single POTCAR names
+    """Replace full POTCAR with only single POTCAR names
 
     Args:
         input_file_name: path of POTCAR file

--- a/vasp_manager/vasp_input_creator.py
+++ b/vasp_manager/vasp_input_creator.py
@@ -36,9 +36,7 @@ logger = logging.getLogger(__name__)
 
 
 class VaspInputCreator:
-    """
-    Handles VASP file creation
-    """
+    """Handles VASP file creation"""
 
     def __init__(
         self,
@@ -54,21 +52,20 @@ class VaspInputCreator:
         ncore_per_node_for_memory: int | None = None,
         use_spin: bool = True,
     ) -> None:
-        """
-        Args:
-            calc_dir: directory where VASP input files will be written
-            mode: calculation type (e.g. "rlx", "static", "elastic")
-            structure: pymatgen Structure to use for input generation
-            config_dir: directory containing calc_config.json and
-                computing_config.json
-            name: material name for logging and job naming
-            job_prefix: short prefix for SLURM job names (e.g. "r", "s", "b").
-                If None, derived from mode for backwards compatibility.
-            increase_nodes_by_factor: multiply node count by this factor
-            increase_walltime_by_factor: multiply walltime by this factor
-            poscar_significant_figures: significant figures for POSCAR coords
-            ncore_per_node_for_memory: cores per node reserved for memory
-            use_spin: pass False to suppress spin polarization
+        """Args:
+        calc_dir: directory where VASP input files will be written
+        mode: calculation type (e.g. "rlx", "static", "elastic")
+        structure: pymatgen Structure to use for input generation
+        config_dir: directory containing calc_config.json and
+            computing_config.json
+        name: material name for logging and job naming
+        job_prefix: short prefix for SLURM job names (e.g. "r", "s", "b").
+            If None, derived from mode for backwards compatibility.
+        increase_nodes_by_factor: multiply node count by this factor
+        increase_walltime_by_factor: multiply walltime by this factor
+        poscar_significant_figures: significant figures for POSCAR coords
+        ncore_per_node_for_memory: cores per node reserved for memory
+        use_spin: pass False to suppress spin polarization
         """
         self.calc_dir = Path(calc_dir)
         self.mode = mode
@@ -133,9 +130,7 @@ class VaspInputCreator:
         return q_mapper
 
     def make_poscar(self) -> None:
-        """
-        Create and write a POSCAR
-        """
+        """Create and write a POSCAR"""
         poscar = Poscar(self.structure)
         poscar_path = self.calc_dir / "POSCAR"
         poscar.write_file(
@@ -143,9 +138,7 @@ class VaspInputCreator:
         )
 
     def make_potcar(self) -> None:
-        """
-        Create and write a POTCAR
-        """
+        """Create and write a POTCAR"""
         potcar_path = self.calc_dir / "POTCAR"
         potcar_dir = self.computing_config.potcar_dir
 
@@ -189,8 +182,7 @@ class VaspInputCreator:
 
     @cached_property
     def n_procs_used(self) -> int:
-        """
-        Total number of actual processors to run VASP, which may be different
+        """Total number of actual processors to run VASP, which may be different
         than the total number of processors requested in SLURM
             Typically request all available processors on each node, and then
             (optionally) leave some empty for memory or ease of division
@@ -208,6 +200,15 @@ class VaspInputCreator:
         return d_f_block
 
     def _check_needs_spin_polarization(self, composition_dict: dict) -> bool:
+        """Check if the structure contains d- or f-block elements requiring spin
+        polarization.
+
+        Args:
+            composition_dict: element symbol -> count mapping from Structure.composition
+
+        Returns:
+            True if any d- or f-block element is present
+        """
         needs_spin_polarization = False
         for el_name in composition_dict:
             if (
@@ -218,6 +219,17 @@ class VaspInputCreator:
         return needs_spin_polarization
 
     def _get_auto_magmom(self, composition_dict: dict) -> str:
+        """Build a VASP MAGMOM tag string with initial moments assigned by element type.
+
+        d-block elements receive 5.0, f-block elements receive 7.0, all others
+        receive 0.0.
+
+        Args:
+            composition_dict: element symbol -> count mapping from Structure.composition
+
+        Returns:
+            MAGMOM tag string, e.g. "MAGMOM = 2*5.0 1*0.0"
+        """
         magmom_string = "MAGMOM ="
         for el_name in composition_dict:
             if el_name in self.d_f_block["d_block"]:
@@ -244,6 +256,19 @@ class VaspInputCreator:
         hubbards_type: str | None,
         composition_dict: dict,
     ) -> bool:
+        """Check if the structure requires DFT+U corrections.
+
+        DFT+U is applied only when the structure contains both oxygen and a
+        d/f-block element with a Hubbard U entry in hubbards.json.
+
+        Args:
+            hubbards_type: Hubbard parametrization scheme (e.g. "wang"), or None/False
+                to skip DFT+U
+            composition_dict: element symbol -> count mapping from Structure.composition
+
+        Returns:
+            True if DFT+U should be applied
+        """
         if not hubbards_type:
             return False
 
@@ -258,6 +283,15 @@ class VaspInputCreator:
         return needs_dftu
 
     def _get_ldau_string(self, hubbards_type: str, composition_dict: dict) -> str:
+        """Build the DFT+U block for the INCAR (LDAU, LDAUU, LDAUJ, LDAUL tags).
+
+        Args:
+            hubbards_type: Hubbard parametrization scheme (e.g. "wang")
+            composition_dict: element symbol -> count mapping from Structure.composition
+
+        Returns:
+            multi-line string containing LDAU = .TRUE., LDAUPRINT, LDAUU, LDAUJ, LDAUL
+        """
         u_string = "LDAUU ="
         j_string = "LDAUJ ="
         l_string = "LDAUL ="
@@ -282,6 +316,16 @@ class VaspInputCreator:
         return ldau_string
 
     def _get_lmaxmix(self, composition_dict: dict) -> int:
+        """Determine the LMAXMIX value based on element types present.
+
+        LMAXMIX = 6 for f-block elements, 4 for d-block, 2 otherwise.
+
+        Args:
+            composition_dict: element symbol -> count mapping from Structure.composition
+
+        Returns:
+            LMAXMIX value for the INCAR
+        """
         d_block_elements = self.d_f_block["d_block"]
         f_block_elements = self.d_f_block["f_block"]
         lmaxmix = 2
@@ -294,8 +338,7 @@ class VaspInputCreator:
         return lmaxmix
 
     def make_incar(self) -> None:
-        """
-        Create and write an INCAR
+        """Create and write an INCAR
 
         Current kpoints coming from the kspacing tag in the INCAR,
             but future versions should include ability to make kpoints from kppra
@@ -387,6 +430,11 @@ class VaspInputCreator:
             fw.write(incar)
 
     def make_kpoints(self) -> None:
+        """Create and write a Gamma-centered KPOINTS file.
+
+        K-point grid is derived from kspacing in calc_config and the reciprocal
+        lattice vectors of the structure.
+        """
         kpoints_path = self.calc_dir / "KPOINTS"
         kspacing = self.calc_config.kspacing
         reciprocal_lattice = self.structure.lattice.reciprocal_lattice
@@ -402,8 +450,7 @@ class VaspInputCreator:
 
     @staticmethod
     def parse_walltime(walltime: str) -> timedelta:
-        """
-        Convert HH:MM:SS to timedelta
+        """Convert HH:MM:SS to timedelta
         Enforces strict HH:MM:SS format
         Raises ValueError on invalid format.
         """
@@ -420,9 +467,7 @@ class VaspInputCreator:
 
     @staticmethod
     def format_walltime(walltime: timedelta) -> str:
-        """
-        Convert timedelta to HH:MM:SS
-        """
+        """Convert timedelta to HH:MM:SS"""
         total_seconds = int(walltime.total_seconds())
         hours = total_seconds // 3600
         remaining_seconds_after_hours = total_seconds % 3600
@@ -431,9 +476,7 @@ class VaspInputCreator:
         return f"{hours:02}:{minutes:02}:{seconds:02}"
 
     def make_vaspq(self) -> None:
-        """
-        Create and write vasp.q file
-        """
+        """Create and write vasp.q file"""
         vaspq_path = self.calc_dir / "vasp.q"
 
         if self.job_prefix is None:
@@ -499,8 +542,7 @@ class VaspInputCreator:
         vaspq_path.chmod(vaspq_path.stat().st_mode | stat.S_IEXEC)
 
     def make_archive(self) -> Path | None:
-        """
-        Archive current VASP files into an archive_N/ subdirectory.
+        """Archive current VASP files into an archive_N/ subdirectory.
 
         Returns:
             archive_path: path to the created archive directory, or None if
@@ -546,8 +588,7 @@ class VaspInputCreator:
                 return self.calc_dir / archive_name
 
     def create(self) -> None:
-        """
-        Make VASP input files
+        """Make VASP input files
 
         Note:
             Don't touch the order! make_incar and make_vaspq rely on the poscar and

--- a/vasp_manager/vasp_manager.py
+++ b/vasp_manager/vasp_manager.py
@@ -59,9 +59,8 @@ ASCII_LOGO = r"""
 
 
 class VaspManager:
-    """
-    Handles set up and execution of each CalculationManager
-        (rlx-coarse, rlx, static, bulkmod, elastic)
+    """Handles set up and execution of each CalculationManager
+    (rlx-coarse, rlx, static, bulkmod, elastic)
     """
 
     def __init__(
@@ -79,31 +78,30 @@ class VaspManager:
         magmom_per_atom_cutoff: float = 0.0,
         sort_by: Callable[[str], str] = str,
     ) -> None:
-        """
-        Args:
-            calculation_types: list of calculation types
-            material_dirs: list of material directory paths or name of
-                calculations directory
-            to_rerun: if True, rerun failed calculations
-            to_submit: if True, submit calculations
-            ignore_personal_errors: if True, ignore job submission errors if on
-                personal computer
-            tail: number of last lines from stdout.txt to log in debugging
-                if job failed
-            use_multiprocessing: if True, use ProcessPoolExecutor
-            ncore: if ncore, use {ncore} processes for multiprocessing
-                if None, defaults to minimum(number of materials, 4)
-            calculation_manager_kwargs: contains subdictionaries for each
-                calculation type. Each subdictorary can be filled with extra kwargs
-                to pass to its associated CalculationManager during instantiation
-            max_reruns: the maximum number of times a rlx-coarse or rlx
-                calculation can run before refusing to continue
-                Note: other modes don't make archives, so they are not affected
-                by this
-            magmom_per_atom_cutoff: calculations that result in
-                magmom_per_atom less than this parameter will be automatically
-                rerun without spin-polarization
-            sort_by: function to sort the keys of the result dictionary
+        """Args:
+        calculation_types: list of calculation types
+        material_dirs: list of material directory paths or name of
+            calculations directory
+        to_rerun: if True, rerun failed calculations
+        to_submit: if True, submit calculations
+        ignore_personal_errors: if True, ignore job submission errors if on
+            personal computer
+        tail: number of last lines from stdout.txt to log in debugging
+            if job failed
+        use_multiprocessing: if True, use ProcessPoolExecutor
+        ncore: if ncore, use {ncore} processes for multiprocessing
+            if None, defaults to minimum(number of materials, 4)
+        calculation_manager_kwargs: contains subdictionaries for each
+            calculation type. Each subdictorary can be filled with extra kwargs
+            to pass to its associated CalculationManager during instantiation
+        max_reruns: the maximum number of times a rlx-coarse or rlx
+            calculation can run before refusing to continue
+            Note: other modes don't make archives, so they are not affected
+            by this
+        magmom_per_atom_cutoff: calculations that result in
+            magmom_per_atom less than this parameter will be automatically
+            rerun without spin-polarization
+        sort_by: function to sort the keys of the result dictionary
         """
         print(ASCII_LOGO)
         self.sort_by = sort_by
@@ -200,8 +198,7 @@ class VaspManager:
 
     @material_dirs.setter
     def material_dirs(self, values: Filepaths | WorkingDirectory) -> None:
-        """
-        Sets paths for all materials
+        """Sets paths for all materials
 
         Args:
             values: list of material directory
@@ -258,8 +255,7 @@ class VaspManager:
     def _build_active_dependencies(
         calc_types: Sequence[str],
     ) -> dict[str, list[str]]:
-        """
-        Build a dependency graph restricted to the requested calculation types.
+        """Build a dependency graph restricted to the requested calculation types.
 
         An edge is only included when both the dependent calc type and its
         dependency are present in calc_types, reflecting that dependencies are
@@ -276,8 +272,7 @@ class VaspManager:
 
     @staticmethod
     def _toposort(dependencies: dict[str, list[str]]) -> list[str]:
-        """
-        Return nodes in dependency order using Kahn's algorithm.
+        """Return nodes in dependency order using Kahn's algorithm.
 
         Args:
             dependencies: adjacency list mapping each node to its list of
@@ -312,8 +307,7 @@ class VaspManager:
         material_name: str,
         calc_type: str,
     ) -> tuple[bool, bool]:
-        """
-        Checks if job has been completed and analyzed
+        """Checks if job has been completed and analyzed
 
         Args:
             material_name: name of material to check
@@ -335,9 +329,7 @@ class VaspManager:
         return (is_done, is_stopped)
 
     def _get_calculation_managers(self, material_dir: Path) -> list[CalculationManager]:
-        """
-        Gets calculation managers for a single material
-        """
+        """Gets calculation managers for a single material"""
         active_dependencies = self._build_active_dependencies(self.calculation_types)
         calc_managers: list[CalculationManager] = []
         for calc_type in self.calculation_types:
@@ -403,18 +395,14 @@ class VaspManager:
         return calc_managers
 
     def _get_all_calculation_managers(self) -> dict[str, list[CalculationManager]]:
-        """
-        Gets calculation managers for all materials
-        """
+        """Gets calculation managers for all materials"""
         calc_managers = {}
         for material_name, material_dir in zip(self.material_names, self.material_dirs):
             calc_managers[material_name] = self._get_calculation_managers(material_dir)
         return calc_managers
 
     def _manage_calculations(self, material_name: str) -> tuple[str, None | str | dict]:
-        """
-        Runs vasp job workflow for a single material
-        """
+        """Runs vasp job workflow for a single material"""
         material_results: dict[str, Any] = {}
         active_dependencies = self._build_active_dependencies(self.calculation_types)
         done_modes: set[str] = set()
@@ -470,9 +458,7 @@ class VaspManager:
         return results
 
     def run_calculations(self) -> dict:
-        """
-        Runs vasp job workflow for all materials
-        """
+        """Runs vasp job workflow for all materials"""
         results = self._manage_calculations_wrapper()
         for material_name, material_result in results:
             self.results[material_name].update(material_result)
@@ -490,8 +476,7 @@ class VaspManager:
         print_unfinished: bool = False,
         print_stopped: bool = True,
     ) -> str | dict:
-        """
-        Create a string summary of all calculations
+        """Create a string summary of all calculations
 
         Args:
             as_string: if True, return string summary. Else, return dict summary
@@ -499,6 +484,9 @@ class VaspManager:
                 materials for each calculation type in the summary
             print_stopped: if True, include a list of stopped materials for
                 each calculation type in the summary
+
+        Returns:
+            summary string if as_string is True, else summary dict
         """
         if not self.results_path.exists():
             raise ValueError(f"Can't find results in {self.results_path}")

--- a/vasp_manager/vasp_run.py
+++ b/vasp_manager/vasp_run.py
@@ -52,8 +52,7 @@ class VaspRun:
         self,
         extra_errors: list[str] | None = None,
     ) -> set[str]:
-        """
-        Find VASP errors in stdout and stderr
+        """Find VASP errors in stdout and stderr
 
         Args:
             extra_errors: names of other errors to include in search
@@ -83,8 +82,7 @@ class VaspRun:
         return errors_found
 
     def address_vasp_errors(self, errors: set[str]) -> bool:
-        """
-        Try to automatically fix known VASP errors by modifying VIC settings.
+        """Try to automatically fix known VASP errors by modifying VIC settings.
 
         Args:
             errors: set of errors found in stdout or stderr


### PR DESCRIPTION
- Standardize all docstrings across 16 files to follow Google-style format
- Add missing `Args`, `Returns`, and `Raises` sections to public methods
- Add class-level and property docstrings to all modules (`vasp_manager.py`, `base.py`, `job_manager.py`, `vasp_input_creator.py`, `bulkmod_analyzer.py`, `elastic_analyzer.py`, and all five calculation managers)