### PR TITLE
Rerun bulkmod strain when stdout.txt is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Handle extraction from compressed archive dirs for calculation restarts
 - Update zip_outputs and unzip_outputs to be python scripts
 
+## Fixed
+- Fix bulkmod strain rerun when missing stdout
+
 
 ## [2.0.1] 2026-04-07
 

--- a/vasp_manager/calculation_manager/bulkmod.py
+++ b/vasp_manager/calculation_manager/bulkmod.py
@@ -294,6 +294,13 @@ class BulkmodCalculationManager(BaseCalculationManager):
         for i, (strain_name, run) in enumerate(self.vasp_runs.items()):
             stdout_path = run.run_dir / "stdout.txt"
             if not stdout_path.exists():
+                if self.to_rerun:
+                    self.logger.info(f"Rerunning {strain_name} (missing stdout.txt)")
+                    self._clean_strain(strain_name)
+                    new_run = self._setup_strain(i)
+                    self._vasp_runs[strain_name] = new_run
+                    if self.to_submit:
+                        new_run.job_manager.submit_job()
                 all_passed = False
                 continue
 


### PR DESCRIPTION
Previously a missing stdout.txt would silently skip the strain. Now clean and re-setup the strain directory so it gets resubmitted.