### PR TITLE
Fix tqdm progress bar advancing on task submission instead of completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## Changed
+### Changed
 
 - Handle extraction from compressed archive dirs for calculation restarts
 - Update zip_outputs and unzip_outputs to be python scripts
 
-## Fixed
+### Fixed
+
 - Fix bulkmod strain rerun when missing stdout
+- Fix `tqdm` progress bar completing instantly in multiprocessing mode by switching to `executor.submit` + `as_completed`
 
 
 ## [2.0.1] 2026-04-07

--- a/vasp_manager/vasp_manager.py
+++ b/vasp_manager/vasp_manager.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import json
 import logging
 from collections.abc import Callable, Sequence
-from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures import ProcessPoolExecutor, as_completed
 from functools import cached_property
 from importlib.metadata import version
 from pathlib import Path
@@ -442,11 +442,13 @@ class VaspManager:
     def _manage_calculations_wrapper(self) -> list[tuple]:
         if self.use_multiprocessing:
             with ProcessPoolExecutor(max_workers=self.ncore) as executor:
-                results = list(
-                    executor.map(
-                        self._manage_calculations, tqdm(self.material_names), chunksize=1
-                    )
-                )
+                futures = {
+                    executor.submit(self._manage_calculations, name): name
+                    for name in self.material_names
+                }
+                results = []
+                for future in tqdm(as_completed(futures), total=len(futures)):
+                    results.append(future.result())
         else:
             results = []
             for i, material_name in enumerate(self.material_names):


### PR DESCRIPTION
Use executor.submit + as_completed so the bar ticks as workers finish, not as tasks are submitted to the pool.